### PR TITLE
Fix payment method image lookup in plugin assets

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1753,8 +1753,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		$image_extension = apply_filters( 'wc_payment_gateway_' . $this->get_plugin()->get_id() . '_use_svg', true ) ? '.svg' : '.png';
 
 		// first, is the card image available within the plugin?
-		if ( is_readable( $this->get_plugin()->get_payment_gateway_framework_assets_path() . '/images/card-' . $image_type . $image_extension ) ) {
-			return \WC_HTTPS::force_https_url( $this->get_plugin()->get_payment_gateway_framework_assets_url() . '/images/card-' . $image_type . $image_extension );
+		if ( is_readable( $this->get_plugin()->get_plugin_path() . '/assets/images/card-' . $image_type . $image_extension ) ) {
+			return \WC_HTTPS::force_https_url( $this->get_plugin()->get_plugin_url() . '/assets/images/card-' . $image_type . $image_extension );
 		}
 
 		// default: is the card image available within the framework?


### PR DESCRIPTION
This PR fixes the lookup of payment method images as expected:

1. Trying to find the image in `plugin/assets/images/card-<method_name>.ext`
2. If the first image doesn't exist, look in the framework assets folder

Closes #561 