### PR TITLE
Default HPOS support added for all gateway in framework

### DIFF
--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -45,6 +45,9 @@ abstract class SV_WC_Plugin {
 	/** Plugin Framework Version */
 	const VERSION = '5.10.14';
 
+	/** Default support for HPOS */
+	const SUPPORTS_HPOS = true;
+
 	/** @var object single instance of plugin */
 	protected static $instance;
 
@@ -275,6 +278,9 @@ abstract class SV_WC_Plugin {
 
 		// hook for translations separately to ensure they're loaded
 		add_action( 'init', array( $this, 'load_translations' ) );
+
+		// Add high performance order storage compatibility
+		add_action( 'before_woocommerce_init', array( $this, 'add_hpos_compatibility' ) );
 
 		// add the admin notices
 		add_action( 'admin_notices', array( $this, 'add_admin_notices' ) );
@@ -1454,6 +1460,17 @@ abstract class SV_WC_Plugin {
 		wc_deprecated_function( __METHOD__, '5.2.0' );
 	}
 
+	/**
+	 * Add the HPOS compatibility.
+	 *
+	 * @since x.y.z
+	 */
+	public function add_hpos_compatibility() {
+
+		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', $this->get_plugin_file(), static::SUPPORTS_HPOS );
+		}
+	}
 
 }
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -128,7 +128,7 @@ abstract class SV_WC_Plugin {
 		$args = wp_parse_args( $args, [
 			'text_domain'   => '',
 			'dependencies'  => [],
-			'hpos_support' => false
+			'hpos_support' => false,
 		] );
 
 		$this->text_domain  = $args['text_domain'];

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -621,7 +621,7 @@ abstract class SV_WC_Plugin {
 	public function handle_hpos_compatibility() {
 
 		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
-			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', $this->get_plugin_file(), $this->supports_hpos() );
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', $this->get_plugin_file(), $this->is_hpos_compatible() );
 		}
 	}
 
@@ -820,7 +820,7 @@ abstract class SV_WC_Plugin {
 	 *
 	 * @return bool
 	 */
-	public function supports_hpos() : bool
+	public function is_hpos_compatible() : bool
 	{
 		return $this->supports_hpos;
 	}
@@ -1286,7 +1286,7 @@ abstract class SV_WC_Plugin {
 					if ( SV_WC_Helper::str_exists( $plugin, '/' ) ) {
 
 						// normal plugin name (plugin-dir/plugin-filename.php)
-						list( , $filename ) = explode( '/', $plugin );
+						[ , $filename ] = explode( '/', $plugin );
 
 					} else {
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -45,9 +45,6 @@ abstract class SV_WC_Plugin {
 	/** Plugin Framework Version */
 	const VERSION = '5.10.14';
 
-	/** Default support for HPOS */
-	const SUPPORTS_HPOS = true;
-
 	/** @var object single instance of plugin */
 	protected static $instance;
 
@@ -96,6 +93,8 @@ abstract class SV_WC_Plugin {
 	/** @var SV_WC_Admin_Notice_Handler the admin notice handler class */
 	private $admin_notice_handler;
 
+	/** @var bool the plugin high performant order storage support */
+	protected $hpos_support;
 
 	/**
 	 * Initialize the plugin.
@@ -129,9 +128,11 @@ abstract class SV_WC_Plugin {
 		$args = wp_parse_args( $args, [
 			'text_domain'   => '',
 			'dependencies'  => [],
+			'hpos_support' => false
 		] );
 
-		$this->text_domain = $args['text_domain'];
+		$this->text_domain  = $args['text_domain'];
+		$this->hpos_support = $args['hpos_support'];
 
 		// includes that are required to be available at all times
 		$this->includes();
@@ -279,8 +280,8 @@ abstract class SV_WC_Plugin {
 		// hook for translations separately to ensure they're loaded
 		add_action( 'init', array( $this, 'load_translations' ) );
 
-		// Add high performance order storage compatibility
-		add_action( 'before_woocommerce_init', array( $this, 'add_hpos_compatibility' ) );
+		// Handle high performance order storage compatibility
+		add_action( 'before_woocommerce_init', array( $this, 'handle_hpos_compatibility' ) );
 
 		// add the admin notices
 		add_action( 'admin_notices', array( $this, 'add_admin_notices' ) );
@@ -1461,14 +1462,15 @@ abstract class SV_WC_Plugin {
 	}
 
 	/**
-	 * Add the HPOS compatibility.
+	 * Handle the HPOS compatibility.
 	 *
+	 * @internal
 	 * @since x.y.z
 	 */
-	public function add_hpos_compatibility() {
+	public function handle_hpos_compatibility() {
 
 		if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
-			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', $this->get_plugin_file(), static::SUPPORTS_HPOS );
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', $this->get_plugin_file(), $this->hpos_support );
 		}
 	}
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -96,6 +96,7 @@ abstract class SV_WC_Plugin {
 	/** @var SV_WC_Admin_Notice_Handler the admin notice handler class */
 	private $admin_notice_handler;
 
+
 	/**
 	 * Initialize the plugin.
 	 *
@@ -1286,7 +1287,7 @@ abstract class SV_WC_Plugin {
 					if ( SV_WC_Helper::str_exists( $plugin, '/' ) ) {
 
 						// normal plugin name (plugin-dir/plugin-filename.php)
-						[ , $filename ] = explode( '/', $plugin );
+						list( , $filename ) = explode( '/', $plugin );
 
 					} else {
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -612,7 +612,7 @@ abstract class SV_WC_Plugin {
 
 
 	/**
-	 * Adds HPOS compatibility if the plugin is compatible with HPOS.
+	 * Declares HPOS compatibility if the plugin is compatible with HPOS.
 	 *
 	 * @internal
 	 *
@@ -1286,7 +1286,7 @@ abstract class SV_WC_Plugin {
 					if ( SV_WC_Helper::str_exists( $plugin, '/' ) ) {
 
 						// normal plugin name (plugin-dir/plugin-filename.php)
-						[ , $filename ] = explode( '/', $plugin );
+						list( , $filename ) = explode( '/', $plugin );
 
 					} else {
 
@@ -1489,6 +1489,7 @@ abstract class SV_WC_Plugin {
 
 		wc_deprecated_function( __METHOD__, '5.2.0' );
 	}
+
 
 }
 


### PR DESCRIPTION
## Summary

we can automate the way a plugin utilizing the framework can declare whether it is supporting HPOS. We could accomplish this by adding a property SV_WC_Plugin::$supports_hpos : bool (default true) and have individual plugins override it if necessary (plugins adopting the new Framework version should support HPOS by default).

### Story: [MWC-9700](https://godaddy-corp.atlassian.net/browse/MWC-9700)

## QA

- [ ] Code review
- [ ] Override the `hpos_support`  value to `false` in the gateway class
- [ ] You will see this warning in WooCommerce > Settings > Advanced > Features.
<img width="1292" alt="image" src="https://user-images.githubusercontent.com/17900945/211642546-6321fe77-d20a-4d28-be00-18d3529ff715.png">




