### PR TITLE
Added static helper methods to detect admin screen_id and get orders

### DIFF
--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -569,12 +569,11 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * @since x.y.z
 	 *
 	 * @param array $args Array of args.
-	 * @param bool $use_get_posts. Whether to use get_posts() method if HPOS is disabled. Defaults to false.
 	 * @return mixed
 	 */
-	public static function get_orders( $args, bool $use_get_posts = false ) {
+	public static function get_orders( $args ) {
 
-		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() && $use_get_posts ) {
+		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
 			return get_posts( $args );
 		}
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -534,7 +534,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 *
 	 * @return string
 	 */
-	public static function get_screen_id( ) {
+	public static function get_screen_id( ) : string {
 
 		return SV_WC_Plugin_Compatibility::is_hpos_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
 	}
@@ -548,7 +548,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 * @param int $post_id post ID.
 	 * @return bool
 	 */
-	public static function is_order( $post_id ) {
+	public static function is_order( int $post_id ) : bool {
 
 		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
 			return 'shop_order' === get_post_type( $post_id );

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -24,6 +24,8 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_10_14;
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 defined( 'ABSPATH' ) or exit;
 
 if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_10_14\\SV_WC_Order_Compatibility' ) ) :
@@ -519,6 +521,64 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 		}
 
 		return $order_url;
+	}
+
+
+	/**
+	 * Returns the admin screen id for orders.
+	 *
+	 * This method detects the screen_id according to HPOS availability,
+	 * as cannot rely anymore on the shop_order registered post type as the screen ID.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return string
+	 */
+	public static function get_screen_id( ) {
+
+		return SV_WC_Plugin_Compatibility::is_hpos_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+	}
+
+
+	/**
+	 * Determines whether the given $post_id is a WooCommerce order or not according to HPOS availability.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param int $post_id post ID.
+	 * @return bool
+	 */
+	public static function is_order( $post_id ) {
+
+		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
+			return 'shop_order' === get_post_type( $post_id );
+		}
+
+		return 'shop_order' === OrderUtil::get_order_type( $post_id );
+	}
+
+
+	/**
+	 * Get WC orders using wc_get_orders() or get_posts() methods.
+	 *
+	 * Uses wc_get_orders() to get orders using new arguments introduced with HPOS,
+	 * also allows using get_posts() for the backward compatibility if HPOS is inactive and $use_get_posts is set to 'true'.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/wiki/HPOS:-new-order-querying-APIs
+	 *
+	 * @since x.y.z
+	 *
+	 * @param array $args Array of args.
+	 * @param bool $use_get_posts. Whether to use get_posts() method if HPOS is disabled. Defaults to false.
+	 * @return mixed
+	 */
+	public static function get_orders( $args, bool $use_get_posts = false ) {
+
+		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() && $use_get_posts ) {
+			return get_posts( $args );
+		}
+
+		return wc_get_orders( $args );
 	}
 
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -525,10 +525,10 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 
 
 	/**
-	 * Returns the admin screen id for orders.
+	 * Gets the admin screen ID for orders.
 	 *
-	 * This method detects the screen_id according to HPOS availability,
-	 * as cannot rely anymore on the shop_order registered post type as the screen ID.
+	 * This method detects the expected orders screen ID according to HPOS availability.
+	 * `shop_order` as a registered post type as the screen ID is no longer used when HPOS is active.
 	 *
 	 * @since x.y.z
 	 *
@@ -536,12 +536,14 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function get_screen_id( ) : string {
 
-		return SV_WC_Plugin_Compatibility::is_hpos_enabled() ? wc_get_page_screen_id( 'shop-order' ) : 'shop_order';
+		return SV_WC_Plugin_Compatibility::is_hpos_enabled()
+			? wc_get_page_screen_id( 'shop-order' )
+			: 'shop_order';
 	}
 
 
 	/**
-	 * Determines whether the given $post_id is a WooCommerce order or not according to HPOS availability.
+	 * Determines whether a given identifier is a WooCommerce order or not according to HPOS availability.
 	 *
 	 * @since x.y.z
 	 *

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -545,16 +545,22 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 *
 	 * @since x.y.z
 	 *
-	 * @param int $post_id post ID.
+	 * @param int|\WP_Post|\WC_Order|null $post_order_or_id identifier of a possible order
 	 * @return bool
 	 */
-	public static function is_order( int $post_id ) : bool {
+	public static function is_order( $post_order_or_id ) : bool {
 
 		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
-			return 'shop_order' === get_post_type( $post_id );
+
+			if ( $post_order_or_id instanceof \WC_Order ) {
+				$post_order_or_id = $post_order_or_id->get_id();
+			}
+
+			return is_numeric( $post_order_or_id ) || $post_order_or_id instanceof \WP_Post
+				&& 'shop_order' === get_post_type( $post_order_or_id );
 		}
 
-		return 'shop_order' === OrderUtil::get_order_type( $post_id );
+		return 'shop_order' === OrderUtil::get_order_type( $post_order_or_id );
 	}
 
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -567,29 +567,6 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 
 
 	/**
-	 * Get WC orders using wc_get_orders() or get_posts() methods.
-	 *
-	 * Uses wc_get_orders() to get orders using new arguments introduced with HPOS,
-	 * also allows using get_posts() for the backward compatibility if HPOS is inactive and $use_get_posts is set to 'true'.
-	 *
-	 * @link https://github.com/woocommerce/woocommerce/wiki/HPOS:-new-order-querying-APIs
-	 *
-	 * @since x.y.z
-	 *
-	 * @param array $args Array of args.
-	 * @return mixed
-	 */
-	public static function get_orders( $args ) {
-
-		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
-			return get_posts( $args );
-		}
-
-		return wc_get_orders( $args );
-	}
-
-
-	/**
 	 * Gets the order meta according to HPOS availability.
 	 *
 	 * Uses {@see \WC_Order::get_meta()} if HPOS is enabled, otherwise it uses the WordPress {@see get_post_meta()} function.

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -79,8 +79,9 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 */
 	public function enqueue_scripts( $hook_suffix ) {
 
+		global $post;
 		// Order screen assets
-		if ( 'shop_order' === get_post_type() ) {
+		if ( SV_WC_Order_Compatibility::is_order( $post->ID ) ) {
 
 			// Edit Order screen assets
 			if ( 'post.php' === $hook_suffix ) {
@@ -253,8 +254,9 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 */
 	public function add_capture_button( $order ) {
 
+		global $post;
 		// only display the button for core orders
-		if ( ! $order instanceof \WC_Order || 'shop_order' !== get_post_type( $order->get_id() ) ) {
+		if ( ! $order instanceof \WC_Order || ! SV_WC_Order_Compatibility::is_order( $post->ID ) ) {
 			return;
 		}
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -78,10 +78,10 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 * @param string $hook_suffix page hook suffix
 	 */
 	public function enqueue_scripts( $hook_suffix ) {
-
 		global $post;
+
 		// Order screen assets
-		if ( SV_WC_Order_Compatibility::is_order( $post->ID ) ) {
+		if ( SV_WC_Order_Compatibility::is_order( $post ) ) {
 
 			// Edit Order screen assets
 			if ( 'post.php' === $hook_suffix ) {
@@ -253,10 +253,10 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 * @param \WC_Order $order order object
 	 */
 	public function add_capture_button( $order ) {
-
 		global $post;
+
 		// only display the button for core orders
-		if ( ! $order instanceof \WC_Order || ! SV_WC_Order_Compatibility::is_order( $post->ID ) ) {
+		if ( ! $order instanceof \WC_Order || ! SV_WC_Order_Compatibility::is_order( $post ) ) {
 			return;
 		}
 


### PR DESCRIPTION
# Summary
This PR contains adds helper methods for HPOS-related functionalities.

### Ticket ~~[MWC-9698](https://godaddy-corp.atlassian.net/browse/MWC-9698)~~
### Ticket [MWC-9699](https://godaddy-corp.atlassian.net/browse/MWC-9699)
### Ticket [MWC-10118](https://godaddy-corp.atlassian.net/browse/MWC-10118)

### Details
- Added a helper method to detect the admin screen_id
- Added a helper method to replace the `get_post_type` method with the new logic for order detection, and replaced all the usages in the FW
- ~~Added a helper method to use get WC Orders using the new query arguments introduced with HPOS.~~