### PR TITLE
Update references to WP meta functions to use WC_Data CRUD equivalents

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -2513,8 +2513,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		if ( $response && $response->get_transaction_id() ) {
 
 			$this->update_order_meta( $order, 'trans_id', $response->get_transaction_id() );
-
-			update_post_meta( $order->get_id(), '_transaction_id', $response->get_transaction_id() );
+			$this->update_order_meta( $order, '_transaction_id', $response->get_transaction_id() );
 		}
 
 		// transaction date
@@ -2542,7 +2541,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		if ( $this->is_credit_card_gateway() ) {
 
 			// credit card gateway data
-			if ( $response && $response instanceof SV_WC_Payment_Gateway_API_Authorization_Response ) {
+			if ( $response instanceof SV_WC_Payment_Gateway_API_Authorization_Response ) {
 
 				$this->update_order_meta( $order, 'authorization_amount', $order->payment_total );
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -545,13 +545,21 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 */
 	public function remove_order_meta_from_change_payment( $result, $subscription ) {
 
+		$subscription = is_numeric( $subscription ) ? wcs_get_subscription( $subscription ) : $subscription;
+		$updated_subscription = false;
+
 		// remove order-specific meta
 		foreach ( $this->get_order_specific_meta_keys() as $meta_key ) {
-			delete_post_meta( $subscription->get_id(), $meta_key );
+			$subscription->delete_meta_data( $meta_key );
+			$updated_subscription = true;
+		}
+
+		if ( $updated_subscription ) {
+			$subscription->save_meta_data();
 		}
 
 		// get a fresh subscription object after previous metadata changes
-		$subscription = is_numeric( $subscription ) ? wcs_get_subscription( $subscription ) : $subscription;
+		$subscription = wcs_get_subscription( $subscription );
 
 		$old_payment_method = $subscription->get_meta( '_old_payment_method', true, 'edit' );
 		$new_payment_method = $subscription->get_payment_method( 'edit' );

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -196,6 +196,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 	 * copied over to a renewal order prior to payment processing.
 	 *
 	 * @since 4.1.0
+	 *
 	 * @param \WC_Order $order order
 	 */
 	public function save_payment_meta( $order ) {
@@ -207,14 +208,22 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 		foreach ( $subscriptions as $subscription ) {
 
+			$updated = false;
+
 			// payment token
 			if ( ! empty( $order->payment->token ) ) {
-				update_post_meta( $subscription->get_id(), $this->get_gateway()->get_order_meta_prefix() . 'payment_token', $order->payment->token );
+				$subscription->update_meta_data( $this->get_gateway()->get_order_meta_prefix() . 'payment_token', $order->payment->token );
+				$updated = true;
 			}
 
 			// customer ID
 			if ( ! empty( $order->customer_id ) ) {
-				update_post_meta( $subscription->get_id(), $this->get_gateway()->get_order_meta_prefix() . 'customer_id', $order->customer_id );
+				$subscription->update_meta_data(  $this->get_gateway()->get_order_meta_prefix() . 'customer_id', $order->customer_id );
+				$updated = true;
+			}
+
+			if ( $updated ) {
+				$subscription->save_meta_data();
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This PR updates instances where the FW tries to handle order post meta using WordPress functions like add/get/update/delete_post_meta instead of the WC_Data equivalents. Same applies to Subscriptions: we should use WC methods instead of WP meta functions when handling Subscriptions meta data.

### Story: [MWC-10160](https://godaddy-corp.atlassian.net/browse/MWC-10160)
### Base PR: #584 

## QA

- [ ] Code review
- [ ] Audit the FW codebase [using this regex](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#auditing-the-code-base-for-direct-db-access-usage): you shouldn't see any more instances of WP meta functions used in the codebase with this PR