### PR TITLE
Update admin_footer-post.php and load-edit.php hooks for handling HPOS screens

### DIFF
--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -722,42 +722,6 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	}
 
 
-	/**
-	 * Get global $post or $theorder order object according to HPOS availability.
-	 *
-	 * @since x.y.z
-	 * @return \WC_Order|\WP_Post  object
-	 */
-	public static function get_post_or_order() {
-
-		global $post, $theorder;
-
-		if ( ! is_null( $theorder ) && static::is_order( $theorder ) ) {
-			return $theorder;
-		} else if( ! is_null( $post ) ) {
-			return $post;
-		}
-
-	}
-
-	/**
-	 * Get global $post or $theorder order status.
-	 *
-	 * TODO: Refactor this method to get order status by order object or ID. If object order or ID does not pass in params then get global order status.
-	 * @since x.y.z
-	 * @return string order status
-	 */
-	public static function get_order_status() {
-
-	$post_or_order_object	= static::get_post_or_order();
-
-		if ( $post_or_order_object instanceof \WC_Order ) {
-			return $post_or_order_object->get_status();
-		} elseif ( $post_or_order_object instanceof \WP_Post ) {
-			return get_post_status( $post_or_order_object );
-		}
-	}
-
 }
 
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -641,11 +641,11 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 			return false;
 		}
 
-		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
+		if ( $post_order_or_id instanceof \WC_Abstract_Order ) {
 
-			if ( $post_order_or_id instanceof \WC_Order ) {
-				$post_order_or_id = $post_order_or_id->get_id();
-			}
+			$found_type = $post_order_or_id->get_type();
+
+		} elseif ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
 
 			$found_type = is_numeric( $post_order_or_id ) || $post_order_or_id instanceof \WP_Post ? get_post_type( $post_order_or_id ) : null;
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -523,6 +523,54 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 		return $order_url;
 	}
 
+	/**
+	 * Determines if the current admin screen is for the orders.
+	 *
+	 * @return bool
+	 */
+	public static function is_orders_screen() : bool {
+
+		$current_screen = SV_WC_Helper::get_current_screen();
+
+		if ( ! $current_screen ) {
+			return false;
+		}
+
+		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
+			return 'edit-shop_order' === $current_screen->id;
+		}
+
+		return static::get_order_screen_id() === $current_screen->id
+			&& isset( $_GET['page'] )
+			&& $_GET['page'] === 'wc-orders';
+	}
+
+
+	/**
+	 * Determines if the current admin screen is for adding or editing an order.
+	 *
+	 * @since x.y.z
+	 *
+	 * @return bool
+	 */
+	public static function is_order_edit_screen() : bool {
+
+		$current_screen = SV_WC_Helper::get_current_screen();
+
+		if ( ! $current_screen ) {
+			return false;
+		}
+
+		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
+			return 'shop_order' === $current_screen->id;
+		}
+
+		return static::get_order_screen_id() === $current_screen->id
+			&& isset( $_GET['page'], $_GET['action'] )
+			&& $_GET['page'] === 'wc-orders'
+			&& in_array( $_GET['action'], [ 'new', 'edit'], true );
+	}
+
 
 	/**
 	 * Gets the admin screen ID for orders.

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -527,6 +527,8 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	/**
 	 * Determines if the current admin screen is for the orders.
 	 *
+	 * @since x.y.z
+	 *
 	 * @return bool
 	 */
 	public static function is_orders_screen() : bool {
@@ -544,6 +546,35 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 		return static::get_order_screen_id() === $current_screen->id
 			&& isset( $_GET['page'] )
 			&& $_GET['page'] === 'wc-orders';
+	}
+
+
+	/**
+	 * Determines if the current orders screen is for orders of a specific status.
+	 *
+	 * @since x.y.z
+	 *
+	 * @param string|string[] $status one or more statuses to compare
+	 * @return bool
+	 */
+	public static function is_orders_screen_for_status( $status ) : bool {
+		global $post_type, $post_status;
+
+		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
+
+			if ( 'shop_order' !== $post_type ) {
+				return false;
+			}
+
+			return empty( $status ) || $post_status === $status || ( is_array( $status ) && in_array( $post_status, $status, true ) );
+		}
+
+		if ( ! static::is_orders_screen() ) {
+			return false;
+		}
+
+		return empty( $status )
+			|| ( isset( $_GET['status'] ) && ( $status === $_GET['status'] || is_array( $status ) && in_array( $_GET['status'], $status, true ) ) );
 	}
 
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -509,10 +509,14 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 *
 	 * @since 5.0.1
 	 *
+	 * @deprecated since x.y.z
+	 *
 	 * @param \WC_Order $order order object
 	 * @return string
 	 */
 	public static function get_edit_order_url( \WC_Order $order ) {
+
+		wc_deprecated_function( __METHOD__, 'x.y.z', 'WC_Order::get_edit_order_url' );
 
 		if ( SV_WC_Plugin_Compatibility::is_wc_version_gte( '3.3' ) ) {
 			$order_url = $order->get_edit_order_url();

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -718,6 +718,42 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	}
 
 
+	/**
+	 * Get global $post or $theorder order object according to HPOS availability.
+	 *
+	 * @since x.y.z
+	 * @return \WC_Order|\WP_Post  object
+	 */
+	public static function get_post_or_order() {
+
+		global $post, $theorder;
+
+		if ( ! is_null( $theorder ) && static::is_order( $theorder ) ) {
+			return $theorder;
+		} else if( ! is_null( $post ) ) {
+			return $post;
+		}
+	
+	}
+
+	/**
+	 * Get global $post or $theorder order status.
+	 *
+	 * TODO: Refactor this method to get order status by order object or ID. If object order or ID does not pass in params then get global order status.
+	 * @since x.y.z
+	 * @return string order status
+	 */
+	public static function get_order_status() {
+
+	$post_or_order_object	= static::get_post_or_order();
+
+		if ( $post_or_order_object instanceof \WC_Order ) {
+			return $post_or_order_object->get_status();
+		} elseif ( $post_or_order_object instanceof \WP_Post ) {
+			return get_post_status( $post_or_order_object );
+		}
+	}
+
 }
 
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -523,6 +523,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 		return $order_url;
 	}
 
+
 	/**
 	 * Determines if the current admin screen is for the orders.
 	 *
@@ -568,7 +569,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 		return static::get_order_screen_id() === $current_screen->id
 			&& isset( $_GET['page'], $_GET['action'] )
 			&& $_GET['page'] === 'wc-orders'
-			&& in_array( $_GET['action'], [ 'new', 'edit'], true );
+			&& in_array( $_GET['action'], [ 'new', 'edit' ], true );
 	}
 
 

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -553,6 +553,10 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 	 */
 	public static function is_order( $post_order_or_id, $order_type = 'shop_order' ) : bool {
 
+		if ( ! $post_order_or_id ) {
+			return false;
+		}
+
 		if ( ! SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
 
 			if ( $post_order_or_id instanceof \WC_Order ) {
@@ -733,7 +737,7 @@ class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 		} else if( ! is_null( $post ) ) {
 			return $post;
 		}
-	
+
 	}
 
 	/**

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -143,16 +143,17 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	/**
 	 * Adds 'Capture charge' to the Orders screen bulk action select.
 	 *
+	 * @internal
+	 *
 	 * @since 5.0.0
 	 */
 	public function maybe_add_capture_charge_bulk_order_action() {
-		global $post_type, $post_status;
 
 		if ( ! current_user_can( 'edit_shop_orders' ) ) {
 			return;
 		}
 
-		if ( $post_type === 'shop_order' && $post_status !== 'trash' ) {
+		if ( SV_WC_Order_Compatibility::is_orders_screen_for_status( 'trash' ) ) {
 
 			$can_capture_charge = false;
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -89,11 +89,15 @@ class SV_WC_Payment_Gateway_Admin_Order {
 		if ( SV_WC_Order_Compatibility::is_order( $post ) || SV_WC_Order_Compatibility::is_order( $theorder ) ) {
 
 			// Edit Order screen assets
-			if ( 'post.php' === $hook_suffix ) {
+			if ( 'post.php' === $hook_suffix || SV_WC_Order_Compatibility::is_order_edit_screen() ) {
 
-				$order = wc_get_order( SV_WC_Helper::get_requested_value( 'post' ) );
+				if ( $theorder instanceof \WC_Order ) {
+					$order = $theorder;
+				} else {
+					$order = wc_get_order( SV_WC_Helper::get_requested_value( SV_WC_Plugin_Compatibility::is_hpos_enabled() ? 'id' : 'post' ) );
+				}
 
-				if ( ! $order ) {
+				if ( ! $order instanceof \WC_Order ) {
 					return;
 				}
 
@@ -142,15 +146,13 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 * @since 5.0.0
 	 */
 	public function maybe_add_capture_charge_bulk_order_action() {
+		global $post_type, $post_status;
 
-		global $current_screen;
-
-
-		if ( ! current_user_can( 'edit_shop_orders' )  && $current_screen->id === SV_WC_Order_Compatibility::get_screen_id()) {
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
 			return;
 		}
 
-		if ( 'trash' !== $this->current_action() ) {
+		if ( $post_type === 'shop_order' && $post_status !== 'trash' ) {
 
 			$can_capture_charge = false;
 
@@ -263,7 +265,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 		global $post;
 
 		// only display the button for core orders
-		if ( ! $order instanceof \WC_Order && ! SV_WC_Order_Compatibility::is_order( $post ) ) {
+		if ( ! $order instanceof \WC_Order || ! SV_WC_Order_Compatibility::is_order( $post ) ) {
 			return;
 		}
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -62,8 +62,13 @@ class SV_WC_Payment_Gateway_Admin_Order {
 			add_action( 'wp_ajax_wc_' . $this->get_plugin()->get_id() . '_capture_charge', array( $this, 'ajax_process_capture' ) );
 
 			// bulk capture order action
-			add_action( 'admin_footer', array( $this, 'maybe_add_capture_charge_bulk_order_action' ) );
-			add_action( 'load-edit.php',         array( $this, 'process_capture_charge_bulk_order_action' ) );
+			if ( SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
+				add_action( 'admin_footer', [ $this, 'maybe_add_capture_charge_bulk_order_action' ] );
+				add_action( 'load-admin.php', [ $this, 'process_capture_charge_bulk_order_action' ] );
+			} else {
+				add_action( 'admin_footer-edit.php', [ $this, 'maybe_add_capture_charge_bulk_order_action' ] );
+				add_action( 'load-edit.php', [ $this, 'process_capture_charge_bulk_order_action' ] );
+			}
 		}
 	}
 
@@ -144,7 +149,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 		if ( ! current_user_can( 'edit_shop_orders' )  && $current_screen->id === SV_WC_Order_Compatibility::get_screen_id()) {
 			return;
 		}
-		
+
 		if ( 'trash' !== $this->current_action() ) {
 
 			$can_capture_charge = false;

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -137,15 +137,15 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 * @since 5.0.0
 	 */
 	public function maybe_add_capture_charge_bulk_order_action() {
-		
-		global $post_type, $post_status, $current_screen;
+
+		global $current_screen;
 
 
 		if ( ! current_user_can( 'edit_shop_orders' )  && $current_screen->id === SV_WC_Order_Compatibility::get_screen_id()) {
 			return;
 		}
-
-		if ( $post_type === 'shop_order' && $post_status !== 'trash' ) {
+		
+		if ( 'trash' !== $this->current_action() ) {
 
 			$can_capture_charge = false;
 
@@ -258,7 +258,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 		global $post;
 
 		// only display the button for core orders
-		if ( ! $order instanceof \WC_Order || ! SV_WC_Order_Compatibility::is_order( $post ) ) {
+		if ( ! $order instanceof \WC_Order && ! SV_WC_Order_Compatibility::is_order( $post ) ) {
 			return;
 		}
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -436,6 +436,30 @@ class SV_WC_Payment_Gateway_Admin_Order {
 
 
 	/**
+	 * Gets the current action selected from the bulk actions dropdown.
+	 *
+	 * @see \WP_List_Table::current_action()
+	 * Instead of using _get_list_table() to call current_action() we can duplicate its logic here to grab the action context.
+	 *
+	 * @since 5.10.14
+	 *
+	 * @return string|false the action name or false if no action was detected from the request
+	 */
+	protected function current_action() {
+
+		if ( isset( $_REQUEST['filter_action'] ) && ! empty( $_REQUEST['filter_action'] ) ) {
+			return false;
+		}
+
+		if ( isset( $_REQUEST['action'] ) && -1 != $_REQUEST['action'] ) {
+			return $_REQUEST['action'];
+		}
+
+		return false;
+	}
+
+
+	/**
 	 * Gets the plugin instance.
 	 *
 	 * @since 5.0.0
@@ -525,30 +549,6 @@ class SV_WC_Payment_Gateway_Admin_Order {
 		$gateway = $this->get_order_gateway( $order );
 
 		return $gateway && $gateway->get_capture_handler()->is_order_ready_for_capture( $order );
-	}
-
-
-	/**
-	 * Gets the current action selected from the bulk actions dropdown.
-	 *
-	 * @see \WP_List_Table::current_action()
-	 * Instead of using _get_list_table() to call current_action() we can duplicate its logic here to grab the action context.
-	 *
-	 * @since 5.10.14
-	 *
-	 * @return string|false the action name or false if no action was detected from the request
-	 */
-	protected function current_action() {
-
-		if ( isset( $_REQUEST['filter_action'] ) && ! empty( $_REQUEST['filter_action'] ) ) {
-			return false;
-		}
-
-		if ( isset( $_REQUEST['action'] ) && -1 != $_REQUEST['action'] ) {
-			return $_REQUEST['action'];
-		}
-
-		return false;
 	}
 
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -94,7 +94,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 				if ( $theorder instanceof \WC_Order ) {
 					$order = $theorder;
 				} else {
-					$order = wc_get_order( SV_WC_Helper::get_requested_value( SV_WC_Plugin_Compatibility::is_hpos_enabled() ? 'id' : 'post' ) );
+					$order = wc_get_order( SV_WC_Helper::get_requested_value( SV_WC_Plugin_Compatibility::is_hpos_enabled() ? 'id' : 'post', 0 ) );
 				}
 
 				if ( ! $order instanceof \WC_Order ) {

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -269,10 +269,9 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 * @param \WC_Order $order order object
 	 */
 	public function add_capture_button( $order ) {
-		global $post;
 
 		// only display the button for core orders
-		if ( ! $order instanceof \WC_Order || ! SV_WC_Order_Compatibility::is_order( $post ) ) {
+		if ( ! SV_WC_Order_Compatibility::is_order( $order ) ) {
 			return;
 		}
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -62,7 +62,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 			add_action( 'wp_ajax_wc_' . $this->get_plugin()->get_id() . '_capture_charge', array( $this, 'ajax_process_capture' ) );
 
 			// bulk capture order action
-			add_action( 'admin_footer-edit.php', array( $this, 'maybe_add_capture_charge_bulk_order_action' ) );
+			add_action( 'admin_footer', array( $this, 'maybe_add_capture_charge_bulk_order_action' ) );
 			add_action( 'load-edit.php',         array( $this, 'process_capture_charge_bulk_order_action' ) );
 		}
 	}
@@ -137,9 +137,11 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 * @since 5.0.0
 	 */
 	public function maybe_add_capture_charge_bulk_order_action() {
-		global $post_type, $post_status;
+		
+		global $post_type, $post_status, $current_screen;
 
-		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+
+		if ( ! current_user_can( 'edit_shop_orders' )  && $current_screen->id === SV_WC_Order_Compatibility::get_screen_id()) {
 			return;
 		}
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -80,7 +80,7 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 *
 	 * @since 5.0.0
 	 *
-	 * @param string $hook_suffix page hook suffix
+	 * @param string|mixed $hook_suffix page hook suffix
 	 */
 	public function enqueue_scripts( $hook_suffix ) {
 		global $post, $theorder;
@@ -188,12 +188,18 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	/**
 	 * Processes the 'Capture Charge' custom bulk action.
 	 *
+	 * @internal
+	 *
 	 * @since 5.0.0
 	 */
 	public function process_capture_charge_bulk_order_action() {
 		global $typenow;
 
-		if ( 'shop_order' !== $typenow ) {
+		if ( SV_WC_Plugin_Compatibility::is_hpos_enabled() ) {
+			if ( ! SV_WC_Order_Compatibility::is_orders_screen() ) {
+				return;
+			}
+		} elseif ( 'shop_order' !== $typenow ) {
 			return;
 		}
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -83,10 +83,10 @@ class SV_WC_Payment_Gateway_Admin_Order {
 	 * @param string $hook_suffix page hook suffix
 	 */
 	public function enqueue_scripts( $hook_suffix ) {
-		global $post;
+		global $post, $theorder;
 
 		// Order screen assets
-		if ( SV_WC_Order_Compatibility::is_order( $post ) ) {
+		if ( SV_WC_Order_Compatibility::is_order( $post ) || SV_WC_Order_Compatibility::is_order( $theorder ) ) {
 
 			// Edit Order screen assets
 			if ( 'post.php' === $hook_suffix ) {


### PR DESCRIPTION

## Summary

While testing Authorize mode transaction, I noticed that the Capture Charge button is not showing on the order edit screen.  I figured out why it's not showing,   [admin_footer-edit.php](https://github.com/godaddy-wordpress/wc-plugin-framework/blob/master/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php#L65) hook not working in HPOS-supported WooCommecre.  First, it's not a normal post-type edit screen that's why this hook not working. 

### Story: [MWC-10260](https://godaddy-corp.atlassian.net/browse/MWC-10260) ,  [MWC-10305](https://godaddy-corp.atlassian.net/browse/MWC-10305)
