### PR TITLE
Version changes

### DIFF
--- a/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce-framework-plugin-loader-sample.php
@@ -60,7 +60,7 @@ class SV_WC_Framework_Plugin_Loader {
 	const MINIMUM_WC_VERSION = '3.5';
 
 	/** SkyVerge plugin framework version used by this plugin */
-	const FRAMEWORK_VERSION = '5.10.15'; // TODO: framework version
+	const FRAMEWORK_VERSION = '5.10.16-dev.1'; // TODO: framework version
 
 	/** the plugin name, for displaying notices */
 	const PLUGIN_NAME = 'WooCommerce Framework Plugin'; // TODO: plugin name

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2023.nn.nn - version 5.10.16-dev.1
+ * Fix - Corrected issue when no saved card types are set
+
 2023.02.06 - version 5.10.15
  * Fix - "My Account" delete payment method compatibility with WC 7.2+
 


### PR DESCRIPTION
# Summary

### Issues

- [MWC-10870](https://godaddy-corp.atlassian.net/browse/MWC-10870 (#PR)

### Final issue

## Details

There was an issue with get_card_types function that had issues with PHP8+ causing fatal errors on the Checkout page. The issue was due to the get_card_types array returning an empty string instead of an empty array.

## Before merge

- [ ] I have confirmed the final issue PR is merged


