### PR TITLE
Fix compatibility issue with card types

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -3366,7 +3366,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		assert( $this->supports_card_types() );
 
-		return $this->card_types;
+		return (array) $this->card_types;
 	}
 
 


### PR DESCRIPTION
# Summary

Fixed compatibility issue with get_card_type functions.
### Issue: [MWC-1234](https://godaddy-corp.atlassian.net/browse/MWC-10870)
### Release: #592  (release PR)

## Details

There was an issue with get_card_types function that had issues with PHP8+ causing fatal errors on the Checkout page. The issue was due to the get_card_types array returning an empty string instead of an empty array.

## QA

- [ ] Tests pass

### Setup

- PHP 8+
- Remove all card types from gateway settings

### Steps

1. In the Settings for Authorize.net, remove all Accepted Card Logos from the field.
1. Go through the checkout process to the Checkout page. 
1. With PHP 8.0 or higher, a critical error is generated with a reference to: 
function load_authorize_net_cim_credit_card_payment_form_handler()

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
