### PR TITLE
Update PHP deprecated notice message

### DIFF
--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -261,7 +261,7 @@ class SV_WC_Plugin_Dependencies {
 				sprintf( __( 'Hey there! We\'ve noticed that your server is running %1$san outdated version of PHP%2$s, which is the programming language that WooCommerce and its extensions are built on.', 'woocommerce-plugin-framework' ), '<strong>', '</strong>' ),
 				/* translators: Placeholders: %1$s - <strong> HTML tag, %2$s - </strong> HTML tag */
 				sprintf( __( 'The PHP version that is currently used for your site is no longer maintained, nor %1$sreceives security updates%2$s; newer versions are faster and more secure.', 'woocommerce-plugin-framework' ), '<strong>', '</strong>' ),
-				/* translators: Context: User is running an outdated PHP Version a plugin is not compatible with. Placeholders: %$s - the plugin name */
+				/* translators: Context: User is running an outdated PHP Version a plugin is not compatible with. Placeholders: %s - the plugin name */
 				sprintf( __( 'As a result, %s no longer supports this version and you should upgrade PHP as soon as possible.', 'woocommerce-plugin-framework' ), esc_html( $this->get_plugin()->get_plugin_name() ) ),
 				/* translators: Context: The host can update PHP version for the user. Placeholders: %1$s - <a> HTML tag, %2$s - </a> HTML tag */
 				sprintf( __( 'Your hosting provider can do this for you. %1$sHere are some resources to help you upgrade%2$s and to explain PHP versions further.', 'woocommerce-plugin-framework' ), '<a href="https://wordpress.org/support/update-php/">', '</a>' ),

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -251,7 +251,7 @@ class SV_WC_Plugin_Dependencies {
 	protected function add_deprecated_notices() {
 
 		// add a notice for PHP < 5.6
-		if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
+		if ( version_compare( PHP_VERSION, '7.4.0', '<' ) ) {
 
 			$message = '<p>';
 

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -262,12 +262,12 @@ class SV_WC_Plugin_Dependencies {
 				/* translators: Placeholders: %1$s - <strong> HTML tag, %2$s - </strong> HTML tag */
 				sprintf( __( 'The PHP version that is currently used for your site is no longer maintained, nor %1$sreceives security updates%2$s; newer versions are faster and more secure.', 'woocommerce-plugin-framework' ), '<strong>', '</strong>' ),
 				/* translators: Context: User is running an outdated PHP Version a plugin is not compatible with. Placeholders: %$s - the plugin name */
-				sprintf( __( 'As a result, %s no longer supports this version and you should upgrade PHP as soon as possible.', 'woocommerce-plugin-framework' ), esc_html( $this->get_plugin()->get_plugin_name() ),
+				sprintf( __( 'As a result, %s no longer supports this version and you should upgrade PHP as soon as possible.', 'woocommerce-plugin-framework' ), esc_html( $this->get_plugin()->get_plugin_name() ) ),
 				/* translators: Context: The host can update PHP version for the user. Placeholders: %1$s - <a> HTML tag, %2$s - </a> HTML tag */
-				sprintf( __( 'Your hosting provider can do this for you. %1$sHere are some resources to help you upgrade%2$s and to explain PHP versions further.', 'woocommerce-plugin-framework' ), '<a href="https://wordpress.org/support/update-php/">', '</a>' ) ),
+				sprintf( __( 'Your hosting provider can do this for you. %1$sHere are some resources to help you upgrade%2$s and to explain PHP versions further.', 'woocommerce-plugin-framework' ), '<a href="https://wordpress.org/support/update-php/">', '</a>' ),
 			];
 
-			$message .= implode( "<br>", $lines);
+			$message .= implode( '<br>', $lines);
 			$message .= '</p>';
 
 			$this->add_admin_notice( 'sv-wc-deprecated-php-version', $message, 'error' );

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -255,17 +255,19 @@ class SV_WC_Plugin_Dependencies {
 
 			$message = '<p>';
 
-			$message .= sprintf(
-				/* translators: Placeholders: %1$s - <strong>, %2$s - </strong> */
-				__( 'Hey there! We\'ve noticed that your server is running %1$san outdated version of PHP%2$s, which is the programming language that WooCommerce and its extensions are built on.
-					The PHP version that is currently used for your site is no longer maintained, nor %1$sreceives security updates%2$s; newer versions are faster and more secure.
-					As a result, %3$s no longer supports this version and you should upgrade PHP as soon as possible.
-					Your hosting provider can do this for you. %4$sHere are some resources to help you upgrade%5$s and to explain PHP versions further.', 'woocommerce-plugin-framework' ),
-				'<strong>', '</strong>',
-				esc_html( $this->get_plugin()->get_plugin_name() ),
-				'<a href="http://skyver.ge/upgradephp">', '</a>'
-			);
+			// for translation purposes, it's easier to keep these strings separate to avoid many tabs and newlines in the compiled pot file
+			$lines = [
+				/* translators: Placeholders: %1$s - <strong> HTML tag, %2$s - </strong> HTML tag */
+				sprintf( __( 'Hey there! We\'ve noticed that your server is running %1$san outdated version of PHP%2$s, which is the programming language that WooCommerce and its extensions are built on.', 'woocommerce-plugin-framework' ), '<strong>', '</strong>' ),
+				/* translators: Placeholders: %1$s - <strong> HTML tag, %2$s - </strong> HTML tag */
+				sprintf( __( 'The PHP version that is currently used for your site is no longer maintained, nor %1$sreceives security updates%2$s; newer versions are faster and more secure.', 'woocommerce-plugin-framework' ), '<strong>', '</strong>' ),
+				/* translators: Context: User is running an outdated PHP Version a plugin is not compatible with. Placeholders: %$s - the plugin name */
+				sprintf( __( 'As a result, %s no longer supports this version and you should upgrade PHP as soon as possible.', 'woocommerce-plugin-framework' ), esc_html( $this->get_plugin()->get_plugin_name() ),
+				/* translators: Context: The host can update PHP version for the user. Placeholders: %1$s - <a> HTML tag, %2$s - </a> HTML tag */
+				sprintf( __( 'Your hosting provider can do this for you. %1$sHere are some resources to help you upgrade%2$s and to explain PHP versions further.', 'woocommerce-plugin-framework' ), '<a href="https://wordpress.org/support/update-php/">', '</a>' ) ),
+			];
 
+			$message .= implode( "\n", $lines);
 			$message .= '</p>';
 
 			$this->add_admin_notice( 'sv-wc-deprecated-php-version', $message, 'error' );

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -267,7 +267,7 @@ class SV_WC_Plugin_Dependencies {
 				sprintf( __( 'Your hosting provider can do this for you. %1$sHere are some resources to help you upgrade%2$s and to explain PHP versions further.', 'woocommerce-plugin-framework' ), '<a href="https://wordpress.org/support/update-php/">', '</a>' ) ),
 			];
 
-			$message .= implode( "\n", $lines);
+			$message .= implode( "<br>", $lines);
 			$message .= '</p>';
 
 			$this->add_admin_notice( 'sv-wc-deprecated-php-version', $message, 'error' );

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -250,7 +250,7 @@ class SV_WC_Plugin_Dependencies {
 	 */
 	protected function add_deprecated_notices() {
 
-		// add a notice for PHP < 5.6
+		// add a notice for PHP < 7.4
 		if ( version_compare( PHP_VERSION, '7.4.0', '<' ) ) {
 
 			$message = '<p>';


### PR DESCRIPTION
The translations team [asked](https://godaddy.slack.com/archives/C07TDQWJ1/p1695848203867769?thread_ts=1695360403.201719&cid=C07TDQWJ1) to remove multiple tabs/newlines resulting from a translatable string which was typed in a multiline format. I have reworked the long message in individual strings and connected them together via `implode()`.

I also noticed 3 things:

* The message would have been displayed only with users running PHP < 5.6, but both the FW and the plugins now require 7.4, so I updated that version check
* The link to `http://skyver.ge/upgradephp` no longer works and I replaced it with a WordPress.org page equivalent

**HOWEVER**

* Do we even need this anymore? Because theoretically with v5.5+ of the plugin framework we have the fw loader class which will already perform the PHP version check and bail if the PHP version is incorrect. That's probably why this method wasn't updated to the most recent PHP version. If it gets to this method, and PHP is older, chances are the plugin will crash because of the language changes.

if you all agree, we could just simply deprecate the method or make it empty by default. 

## QA

- [ ] Code review
- [ ] The message copy and placeholders are correct (if you want to user test this you can copypaste the change in a running version of a plugin and remove the version check to always display the notice)
