### PR TITLE
Update deprecated event handlers

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2023.nn.nn - version ?.?.?
+ * Fix - Updated deprecated JS event handlers that would have triggered deprecation notices in console
+
 2023.09.28 - version 5.11.9
  * Fix - Prevent prefixed metadata from being included in order item descriptions
 

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -271,7 +271,7 @@ class SV_WC_Admin_Notice_Handler {
 			} );
 
 			// Log and hide legacy notices
-			$( 'a.js-wc-plugin-framework-notice-dismiss' ).click( function( e ) {
+			$( 'a.js-wc-plugin-framework-notice-dismiss' ).on( 'click', function( e ) {
 
 				e.preventDefault();
 

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-my-payment-methods.coffee
@@ -64,7 +64,7 @@ jQuery ( $ ) ->
 			)
 
 			# don't follow the Add Payment Method button URL if it's disabled
-			$( '.button[href*="add-payment-method"]' ).click ( event ) ->
+			$( '.button[href*="add-payment-method"]' ).on 'click', event ->
 				event.preventDefault() if $( this ).hasClass( 'disabled' )
 
 

--- a/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
+++ b/woocommerce/payment-gateway/assets/js/frontend/sv-wc-payment-gateway-payment-form.coffee
@@ -322,7 +322,7 @@ jQuery ( $ ) ->
 			$csc_field = $new_payment_method_selection.find( '.js-sv-wc-payment-gateway-credit-card-form-csc' ).closest( '.form-row' )
 
 			# show/hide the saved payment methods when a saved payment method is de-selected/selected
-			$( "input.js-wc-#{ @id_dasherized }-payment-token" ).change ->
+			$( "input.js-wc-#{ @id_dasherized }-payment-token" ).on 'change', ->
 
 				tokenized_payment_method_selected = $( "input.js-wc-#{ id_dasherized }-payment-token:checked" ).val()
 
@@ -348,7 +348,7 @@ jQuery ( $ ) ->
 
 			# display the 'save payment method' option for guest checkouts if the 'create account' option is checked
 			#  but only hide the input if there is a 'create account' checkbox (some themes just display the password)
-			$( 'input#createaccount' ).change ->
+			$( 'input#createaccount' ).on 'change', ->
 				$parent_row = $( "input.js-wc-#{ id_dasherized }-tokenize-payment-method" ).closest( 'p.form-row' )
 
 				if $( this ).is( ':checked' )

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1530,7 +1530,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			// add inline javascript to show/hide any shared settings fields as needed
 			ob_start();
 			?>
-				$( '#woocommerce_<?php echo $this->get_id(); ?>_enable_csc' ).change( function() {
+				$( '#woocommerce_<?php echo $this->get_id(); ?>_enable_csc' ).on( 'change', function() {
 
 					var enabled = $( this ).is( ':checked' );
 
@@ -1553,7 +1553,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			// add inline javascript
 			ob_start();
 			?>
-				$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_transaction_type' ).change( function() {
+				$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_transaction_type' ).on( 'change', function() {
 
 					var transaction_type = $( this ).val();
 					var hidden_settings   = $( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_charge_virtual_orders, #woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_partial_capture, #woocommerce_<?php echo esc_js( $this->get_id() ); ?>_enable_paid_capture' ).closest( 'tr' );
@@ -1576,7 +1576,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			// add inline javascript
 			ob_start();
 			?>
-				$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_environment' ).change( function() {
+				$( '#woocommerce_<?php echo esc_js( $this->get_id() ); ?>_environment' ).on( 'change', function() {
 
 					// inherit settings from other gateway?
 					var inheritSettings = $( '#woocommerce_<?php echo $this->get_id(); ?>_inherit_settings' ).is( ':checked' );
@@ -1606,7 +1606,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			// add inline javascript to show/hide any shared settings fields as needed
 			ob_start();
 			?>
-				$( '#woocommerce_<?php echo $this->get_id(); ?>_inherit_settings' ).change( function() {
+				$( '#woocommerce_<?php echo $this->get_id(); ?>_inherit_settings' ).on( 'change', function() {
 
 					var enabled = $( this ).is( ':checked' );
 


### PR DESCRIPTION
This PR updates deprecated jQuery event handling, which causes console warnings such as the one below:

![CleanShot 2023-09-28 at 15 33 05@2x](https://github.com/godaddy-wordpress/wc-plugin-framework/assets/77076466/a685808e-e65a-4da3-86cf-3e23c09da466)

## QA

- [x] Code review