### PR TITLE
Add workflows to update & sync translations

### DIFF
--- a/.github/workflows/golf-integration-send-translations.yml
+++ b/.github/workflows/golf-integration-send-translations.yml
@@ -3,7 +3,11 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - master
+      - translation
+  workflow_run:
+    workflows: [ "Update translations files" ]
+    types:
+      - completed
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/.github/workflows/golf-integration-send-translations.yml
+++ b/.github/workflows/golf-integration-send-translations.yml
@@ -1,0 +1,31 @@
+name: GoLF Integration - Send Translations to GoLF
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout action-golf-integration repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+          repository: gdcorp-partners/action-golf-integration
+          ref: 'main'
+          token: ${{ secrets.MWC_GD_ACTIONS_REPO_PAT }}
+          path: action-golf-integration
+          persist-credentials: false
+
+      - name: Branch syncing
+        id: branch_syncing
+        uses: ./action-golf-integration/src/translation-updates/send
+        with:
+          gh_token: ${{ secrets.MWC_GD_ACTIONS_REPO_PAT }}
+          main_branch: master
+          translation_branch: translation

--- a/.github/workflows/golf-integration-send-translations.yml
+++ b/.github/workflows/golf-integration-send-translations.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
         with:
           fetch-depth: 0
 
       - name: Checkout action-golf-integration repository
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
         with:
           repository: gdcorp-partners/action-golf-integration
           ref: 'main'

--- a/.github/workflows/golf-integration-translations-received.yml
+++ b/.github/workflows/golf-integration-translations-received.yml
@@ -1,0 +1,32 @@
+name: GoLF Integration - Sync Translations Received from GoLF
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - translation
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+          fetch-depth: 0
+
+      - name: Checkout action-golf-integration repository
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        with:
+          repository: gdcorp-partners/action-golf-integration
+          ref: 'main'
+          token: ${{ secrets.MWC_GD_ACTIONS_REPO_PAT }}
+          path: action-golf-integration
+          persist-credentials: false
+
+      - name: Branch syncing
+        id: branch_syncing
+        uses: ./action-golf-integration/src/translation-updates/received
+        with:
+          gh_token: ${{ secrets.MWC_GD_ACTIONS_REPO_PAT }}
+          main_branch: master
+          translation_paths: woocommerce/i18n/languages
+          translation_branch: translation

--- a/.github/workflows/golf-integration-translations-received.yml
+++ b/.github/workflows/golf-integration-translations-received.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
         with:
           fetch-depth: 0
 
       - name: Checkout action-golf-integration repository
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
         with:
           repository: gdcorp-partners/action-golf-integration
           ref: 'main'

--- a/.github/workflows/update-translations-files.yml
+++ b/.github/workflows/update-translations-files.yml
@@ -1,0 +1,47 @@
+name: Update translations files
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - woocommerce/i18n/**
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v2 # v2.x.x
+        with:
+          fetch-depth: 0
+
+      - name: Checkout localization-actions repository
+        uses: actions/checkout@v2 # v2.x.x
+        with:
+          repository: gdcorp-partners/localization-actions
+          ref: 'main'
+          token: ${{ secrets.MWC_GD_ACTIONS_REPO_PAT }}
+          path: localization-actions
+          persist-credentials: false
+
+      - name: Generate POT file
+        id: generate_pot
+        uses: ./localization-actions/src/generate-pot
+        with:
+          pot_destination: ./woocommerce/i18n/languages/woocommerce-plugin-framework.pot
+          text_domain: woocommerce-plugin-framework
+          package_name: SkyVerge WooCommerce Plugin Framework
+          main_file: ""
+          main_branch: master
+          gh_token: ${{ secrets.MWC_GD_ACTIONS_REPO_PAT }}
+
+      - name: Convert PO to MO
+        id: convert_po_mo
+        uses: ./localization-actions/src/convert-po-mo
+        with:
+          gh_token: ${{ secrets.MWC_GD_ACTIONS_REPO_PAT }}
+          languages_path: ./woocommerce/i18n/languages
+          main_branch: master

--- a/.github/workflows/update-translations-files.yml
+++ b/.github/workflows/update-translations-files.yml
@@ -34,6 +34,7 @@ jobs:
           pot_destination: ./woocommerce/i18n/languages/woocommerce-plugin-framework.pot
           text_domain: woocommerce-plugin-framework
           package_name: SkyVerge WooCommerce Plugin Framework
+          file_comment: Copyright (c) GoDaddy Operating Company, LLC. All Rights Reserved.
           main_file: ""
           main_branch: master
           gh_token: ${{ secrets.MWC_GD_ACTIONS_REPO_PAT }}

--- a/.github/workflows/update-translations-files.yml
+++ b/.github/workflows/update-translations-files.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
         with:
           fetch-depth: 0
 
       - name: Checkout localization-actions repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1
         with:
           repository: gdcorp-partners/localization-actions
           ref: 'main'

--- a/.github/workflows/update-translations-files.yml
+++ b/.github/workflows/update-translations-files.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@v2 # v2.x.x
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Checkout localization-actions repository
-        uses: actions/checkout@v2 # v2.x.x
+        uses: actions/checkout@v4
         with:
           repository: gdcorp-partners/localization-actions
           ref: 'main'


### PR DESCRIPTION
# Summary <!-- Required -->

Adds workflows to update translations via GH actions & to send and receive translations. This is similar to what we've done for other projects.

## Details

Given that these actions are all related/connected, it seemed to make sense implement all together.

Note that the main branch is `master` rather than `main`, and that the send GH action is triggered by the "update translation files" workflow, as described [here](https://godaddy-corp.atlassian.net/wiki/spaces/MWCENG/pages/53149792/Updating+translations+files+on+WordPress+projects).

## QA

- [ ] Code review
- [ ] The send and receive GH actions meet the [criteria here in step 4.1](https://godaddy-corp.atlassian.net/wiki/spaces/MWCENG/pages/53149991/Integrating+with+GoLF)
- [ ] The update translations GH action meets the [criteria listed here](https://godaddy-corp.atlassian.net/wiki/spaces/MWCENG/pages/53149792/Updating+translations+files+on+WordPress+projects)
- [ ] Potfile headers are ok

## Before merge <!-- Required -->

- [ ] This PR makes the appropriate modifications to automated tests or explains why none are needed
- [ ] This PR makes the appropriate modifications to documentation or explains why none are needed
- [ ] This change does not impact usage or expected outputs of covered code
