### PR TITLE
Replace deprecated `wcs_renewal_order_meta` filter usage with `wc_subscriptions_renewal_order_data`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wc-plugin-framework",
-  "version": "5.11.10",
+  "version": "5.11.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wc-plugin-framework",
-      "version": "5.11.10",
+      "version": "5.11.11",
       "license": "GPL-3.0",
       "devDependencies": {
         "coffeescript": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wc-plugin-framework",
-  "version": "5.11.10",
+  "version": "5.11.11",
   "title": "WooCommerce Plugin Framework",
   "author": "SkyVerge Team",
   "homepage": "https://github.com/skyverge/wc-plugin-framework#readme",

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2023.nn.nn - version 5.11.11-dev
+ * Fix - Replace deprecated `wcs_renewal_order_meta` filter usage with `wc_subscriptions_renewal_order_data`
  * Dev - Replace `supports_hpos` with a `supported_features` key in the main plugin file constructor arguments
  * Dev - Introduce a `Blocks_Handler` class which will be expanded in a future release for adding WooCommerce Cart & Checkout Blocks compatibility
  * Misc - Warn merchants when a plugin is not compatible with Cart or Checkout blocks to prompt switching to legacy shortcodes

--- a/woocommerce/i18n/languages/woocommerce-plugin-framework.pot
+++ b/woocommerce/i18n/languages/woocommerce-plugin-framework.pot
@@ -1,2005 +1,2004 @@
-# Copyright (c) GoDaddy Operating Company, LLC. All Rights Reserved.
 msgid ""
 msgstr ""
-"Project-Id-Version: SkyVerge WooCommerce Plugin Framework 1.0.0 TODO: plugin version\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wc-plugin-framework\n"
-"Last-Translator: plugins@godaddy.com\n"
+"Project-Id-Version: SkyVerge WooCommerce Plugin Framework\n"
+"Report-Msgid-Bugs-To: \n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2023-10-13T06:43:26+00:00\n"
+"POT-Creation-Date: 2023-11-10T09:32:56+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.8.1\n"
+"X-Generator: WP-CLI 2.7.1\n"
 "X-Domain: woocommerce-plugin-framework\n"
 
-#. Plugin Name of the plugin
-msgid "WooCommerce Framework Plugin TODO: plugin name"
-msgstr ""
-
-#. Plugin URI of the plugin
-msgid "http://www.woocommerce.com/products/ TODO: product URL"
-msgstr ""
-
-#. Description of the plugin
-msgid "TODO: plugin description"
-msgstr ""
-
-#. Author of the plugin
-msgid "SkyVerge"
-msgstr ""
-
-#. Author URI of the plugin
-msgid "http://www.woocommerce.com"
-msgstr ""
-
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:182
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:182
 msgid "Thanks for installing %1$s! To get started, take a minute to %2$sread the documentation%3$s :)"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:210
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:210
 msgid "Thanks for installing %1$s! To get started, take a minute to complete these %2$squick and easy setup steps%3$s :)"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:235
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:235
 msgid "Setup"
 msgstr ""
 
 #. translators: Placeholders: %s - plugin name
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:303
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:303
 msgid "%s &rsaquo; Setup"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:350
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:350
 msgid "Oops! An error occurred, please try again."
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:395
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:395
 msgctxt "enhanced select"
 msgid "No matches found"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:396
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:396
 msgctxt "enhanced select"
 msgid "Loading failed"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:397
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:397
 msgctxt "enhanced select"
 msgid "Please enter 1 or more characters"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:398
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:398
 msgctxt "enhanced select"
 msgid "Please enter %qty% or more characters"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:399
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:399
 msgctxt "enhanced select"
 msgid "Please delete 1 character"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:400
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:400
 msgctxt "enhanced select"
 msgid "Please delete %qty% characters"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:401
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:401
 msgctxt "enhanced select"
 msgid "You can only select 1 item"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:402
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:402
 msgctxt "enhanced select"
 msgid "You can only select %qty% items"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:403
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:403
 msgctxt "enhanced select"
 msgid "Loading more results&hellip;"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:404
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:404
 msgctxt "enhanced select"
 msgid "Searching&hellip;"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:488
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:488
 msgid "Ready!"
 msgstr ""
 
 #. translators: Placeholder: %s - plugin name
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:581
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:581
 msgid "Welcome to %s!"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:594
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:594
 msgid "This quick setup wizard will help you configure the basic settings and get you started."
 msgstr ""
 
 #. translators: Placeholder: %s - the plugin name
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:613
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:613
 msgid "%s is ready!"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:670
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:670
 msgid "Next step"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:696
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:696
 msgid "You can also:"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:740
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:770
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:740
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:770
 msgid "View the Docs"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:741
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:741
 msgid "See more setup options"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:742
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:742
 msgid "Learn more about customizing the plugin"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:766
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:766
 msgid "Review Your Settings"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:774
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:774
 msgid "Leave a Review"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:798
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:798
 msgid "Continue"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:958
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:958
 msgid "Return to the WordPress Dashboard"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:960
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:960
 msgid "Not right now"
 msgstr ""
 
-#: woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php:962
+#: admin/abstract-sv-wc-plugin-admin-setup-wizard.php:962
 msgid "Skip this step"
 msgstr ""
 
-#: woocommerce/class-sv-wc-framework-bootstrap.php:268
+#: Blocks/Blocks_Handler.php:126
+msgctxt "Button label"
+msgid "Edit the Checkout Page"
+msgstr ""
+
+#. translators: Context: WordPress blocks and shortcodes. Placeholders: %1$s - Plugin name, %2$s - opening HTML <a> tag, %3$s - closing HTML </a> tag, %4$s - opening HTML <a> tag, %5$s - `[woocommerce_checkout]` shortcode tag, %6$s - closing HTML </a> tag
+#: Blocks/Blocks_Handler.php:131
+msgid "%1$s is not yet compatible with the Checkout block. We recommend %2$sfollowing this guide%3$s to revert to the %4$s%5$s shortcode%6$s."
+msgstr ""
+
+#: Blocks/Blocks_Handler.php:157
+msgctxt "Button label"
+msgid "Edit the Cart Page"
+msgstr ""
+
+#. translators: Context: WordPress blocks and shortcodes. Placeholders: %1$s - Plugin name, %2$s - opening HTML <a> tag, %3$s - closing HTML </a> tag, %4$s - opening HTML <a> tag, %5$s - `[woocommerce_cart]` shortcode tag, %6$s - closing HTML </a> tag
+#: Blocks/Blocks_Handler.php:162
+msgid "%1$s is not yet compatible with the Cart block. We recommend %2$sfollowing this guide%3$s to revert to the %4$s%5$s shortcode%6$s."
+msgstr ""
+
+#: class-sv-wc-framework-bootstrap.php:268
 msgid "The following plugin is disabled because it is out of date and incompatible with newer plugins on your site:"
 msgid_plural "The following plugins are disabled because they are out of date and incompatible with newer plugins on your site:"
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: Context is for plugins to activate or deactivate. HTML Placeholders: %1$s - <a> tag, %2$s - </a> tag, %3$s - <em> tag, %4$s - </em> tag, %5$s - <a> tag, %6$s - </a> tag, %7$s - <a> tag, %8$s - </a> tag
-#: woocommerce/class-sv-wc-framework-bootstrap.php:282
+#: class-sv-wc-framework-bootstrap.php:282
 msgid "To resolve this, please %1$supdate%2$s (recommended) %3$sor%4$s %5$sdeactivate%6$s the above plugin, or %7$sdeactivate the following%8$s:"
 msgid_plural "To resolve this, please %1$supdate%2$s (recommended) %3$sor%4$s %5$sdeactivate%6$s the above plugins, or %7$sdeactivate the following%8$s:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: woocommerce/class-sv-wc-framework-bootstrap.php:303
+#: class-sv-wc-framework-bootstrap.php:303
 msgid "The following plugins are inactive because they require a newer version of WooCommerce:"
 msgstr ""
 
-#: woocommerce/class-sv-wc-framework-bootstrap.php:303
+#: class-sv-wc-framework-bootstrap.php:303
 msgid "The following plugin is inactive because it requires a newer version of WooCommerce:"
 msgstr ""
 
 #. translators: Placeholders: %1$s - plugin name, %2$s - WooCommerce version number
-#: woocommerce/class-sv-wc-framework-bootstrap.php:308
+#: class-sv-wc-framework-bootstrap.php:308
 msgid "%1$s requires WooCommerce %2$s or newer"
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: woocommerce/class-sv-wc-framework-bootstrap.php:312
+#: class-sv-wc-framework-bootstrap.php:312
 msgid "Please %1$supdate WooCommerce%2$s"
 msgstr ""
 
-#: woocommerce/class-sv-wc-helper.php:427
+#: class-sv-wc-helper.php:427
 msgctxt "coordinating conjunction for a list of items: a, b, and c"
 msgid "and"
 msgstr ""
 
 #. translators: A list of items, for example: "US or Canada", or "US, Canada, or Mexico". English uses Oxford comma before the conjunction ("or") if there are at least 2 items preceding it - hence the use of plural forms. If your locale does not use Oxford comma, you can just provide the same translation to all plural forms. Placeholders: %1$s - a comma-separated list of item, %2$s - the final item in the list
-#: woocommerce/class-sv-wc-helper.php:472
+#: class-sv-wc-helper.php:472
 msgid "%1$s or %2$s"
 msgid_plural "%1$s, or %2$s"
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: A list of items, for example: "US and Canada", or "US, Canada, and Mexico". English uses Oxford comma before the conjunction ("and") if there are at least 2 items preceding it - hence the use of plural forms. If your locale does not use Oxford comma, you can just provide the same translation to all plural forms. Placeholders: %1$s - a comma-separated list of items, %2$s - the final item in the list
-#: woocommerce/class-sv-wc-helper.php:478
+#: class-sv-wc-helper.php:478
 msgid "%1$s and %2$s"
 msgid_plural "%1$s, and %2$s"
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: Placeholders: %1$s - plugin name, %2$s - a PHP extension/comma-separated list of PHP extensions
-#: woocommerce/class-sv-wc-plugin-dependencies.php:156
+#: class-sv-wc-plugin-dependencies.php:156
 msgid "%1$s requires the %2$s PHP extension to function. Contact your host or server administrator to install and configure the missing extension."
 msgid_plural "%1$s requires the following PHP extensions to function: %2$s. Contact your host or server administrator to install and configure the missing extensions."
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: Placeholders: %1$s - plugin name, %2$s - a PHP function/comma-separated list of PHP functions
-#: woocommerce/class-sv-wc-plugin-dependencies.php:184
+#: class-sv-wc-plugin-dependencies.php:184
 msgid "%1$s requires the %2$s PHP function to exist.  Contact your host or server administrator to install and configure the missing function."
 msgid_plural "%1$s requires the following PHP functions to exist: %2$s.  Contact your host or server administrator to install and configure the missing functions."
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: Placeholder: %s - a PHP setting value
-#: woocommerce/class-sv-wc-plugin-dependencies.php:228
+#: class-sv-wc-plugin-dependencies.php:228
 msgid "%s or higher"
 msgstr ""
 
-#: woocommerce/class-sv-wc-plugin-dependencies.php:238
+#: class-sv-wc-plugin-dependencies.php:238
 msgid "Please contact your hosting provider or server administrator to configure these settings."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <strong> HTML tag, %2$s - </strong> HTML tag
-#: woocommerce/class-sv-wc-plugin-dependencies.php:261
+#: class-sv-wc-plugin-dependencies.php:261
 msgid "Hey there! We've noticed that your server is running %1$san outdated version of PHP%2$s, which is the programming language that WooCommerce and its extensions are built on."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <strong> HTML tag, %2$s - </strong> HTML tag
-#: woocommerce/class-sv-wc-plugin-dependencies.php:263
+#: class-sv-wc-plugin-dependencies.php:263
 msgid "The PHP version that is currently used for your site is no longer maintained, nor %1$sreceives security updates%2$s; newer versions are faster and more secure."
 msgstr ""
 
 #. translators: Context: User is running an outdated PHP Version a plugin is not compatible with. Placeholders: %s - the plugin name
-#: woocommerce/class-sv-wc-plugin-dependencies.php:265
+#: class-sv-wc-plugin-dependencies.php:265
 msgid "As a result, %s no longer supports this version and you should upgrade PHP as soon as possible."
 msgstr ""
 
 #. translators: Context: The host can update PHP version for the user. Placeholders: %1$s - <a> HTML tag, %2$s - </a> HTML tag
-#: woocommerce/class-sv-wc-plugin-dependencies.php:267
+#: class-sv-wc-plugin-dependencies.php:267
 msgid "Your hosting provider can do this for you. %1$sHere are some resources to help you upgrade%2$s and to explain PHP versions further."
 msgstr ""
 
 #. translators: Placeholders: %s - plugin name
-#: woocommerce/class-sv-wc-plugin.php:310
+#: class-sv-wc-plugin.php:337
 msgid "You cannot clone instances of %s."
 msgstr ""
 
 #. translators: Placeholders: %s - plugin name
-#: woocommerce/class-sv-wc-plugin.php:321
+#: class-sv-wc-plugin.php:348
 msgid "You cannot unserialize instances of %s."
 msgstr ""
 
 #. translators: Docs as in Documentation
-#: woocommerce/class-sv-wc-plugin.php:594
+#: class-sv-wc-plugin.php:621
 msgid "Docs"
 msgstr ""
 
-#: woocommerce/class-sv-wc-plugin.php:599
+#: class-sv-wc-plugin.php:626
 msgctxt "noun"
 msgid "Support"
 msgstr ""
 
-#: woocommerce/class-sv-wc-plugin.php:604
+#: class-sv-wc-plugin.php:631
 msgctxt "verb"
 msgid "Review"
 msgstr ""
 
 #. translators: Placeholders: %1$s - PHP setting value, %2$s - version or value required
-#: woocommerce/class-sv-wc-plugin.php:710
+#: class-sv-wc-plugin.php:757
 msgid "%1$s - A minimum of %2$s is required."
 msgstr ""
 
 #. translators: Context: As in "Value has been set as [foo], but [bar] is required". Placeholders: %1$s - current value for a PHP setting, %2$s - required value for the PHP setting
-#: woocommerce/class-sv-wc-plugin.php:720
+#: class-sv-wc-plugin.php:767
 msgid "Set as %1$s - %2$s is required."
 msgstr ""
 
-#: woocommerce/class-sv-wc-plugin.php:1013
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:870
+#: class-sv-wc-plugin.php:1088
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:870
 msgid "Configure"
 msgstr ""
 
-#: woocommerce/Lifecycle.php:394
+#: Lifecycle.php:394
 msgctxt "Generic congratulatory exclamation at the start of a milestone message"
 msgid "Awesome!"
 msgstr ""
 
-#: woocommerce/Lifecycle.php:395
+#: Lifecycle.php:395
 msgctxt "Generic congratulatory exclamation at the start of a milestone message"
 msgid "Fantastic!"
 msgstr ""
 
-#: woocommerce/Lifecycle.php:396
+#: Lifecycle.php:396
 msgctxt "Generic congratulatory exclamation at the start of a milestone message"
 msgid "Cowabunga!"
 msgstr ""
 
-#: woocommerce/Lifecycle.php:397
+#: Lifecycle.php:397
 msgctxt "Generic congratulatory exclamation at the start of a milestone message"
 msgid "Congratulations!"
 msgstr ""
 
-#: woocommerce/Lifecycle.php:398
+#: Lifecycle.php:398
 msgctxt "Generic congratulatory exclamation at the start of a milestone message"
 msgid "Hot dog!"
 msgstr ""
 
 #. translators: Placeholders: %1$s - Plugin name, %2$s - Opening HTML <a> tag, %3$s - Closing HTML </a> tag, %4$s - Opening HTML <a> tag, %5$s - Closing HTML </a> tag
-#: woocommerce/Lifecycle.php:405
+#: Lifecycle.php:405
 msgid "Are you having a great experience with %1$s so far? Please consider %2$sleaving a review%3$s! If things aren't going quite as expected, we're happy to help -- please %4$sreach out to our support team%5$s."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:130
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:130
 msgctxt "Payment transaction capture"
 msgid "Are you sure you wish to process this capture? The action cannot be undone."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:133
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:133
 msgctxt "Payment transaction capture failed error message"
 msgid "Something went wrong, and the capture could not be completed. Please try again."
 msgstr ""
 
 #. translators: verb, as in "Capture credit card charge". Used when an amount has been pre-authorized before, but funds have not yet been captured (taken) from the card. Capturing the charge will take the money from the credit card and put it in the merchant's pockets.
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:178
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:267
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:330
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:178
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:267
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:330
 msgid "Capture Charge"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:320
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:320
 msgid "This charge has been fully captured."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:322
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:322
 msgid "This charge can no longer be captured."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:324
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php:324
 msgid "This charge cannot be captured."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:91
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:91
 msgid "Are you sure you want to remove this token?"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:101
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:101
 msgid "Invalid token data"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:105
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:105
 msgid "An error occurred. Please try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:491
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php:306
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:491
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php:306
 msgid "(%s)"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:521
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:900
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:521
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:900
 msgid "Default"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:557
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:590
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:557
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:590
 msgid "Token ID"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:562
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:302
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:562
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:302
 msgid "Card Type"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:567
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:603
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:193
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:300
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:567
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:603
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:193
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:300
 msgctxt "Last four digits of a payment method"
 msgid "Last Four"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:574
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:362
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:574
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:362
 msgid "Expiration (MM/YY)"
 msgstr ""
 
 #. translators: e-check account type, HTML form field label
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:595
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:470
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:301
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:595
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:470
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:301
 msgid "Account Type"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:598
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:598
 msgid "Checking"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:599
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:599
 msgid "Savings"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:700
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:700
 msgid "Refresh"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:702
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:702
 msgid "Add New"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:705
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:297
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:705
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:297
 msgid "Save"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:728
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php:728
 msgid "Remove"
 msgstr ""
 
 #. translators: Placeholder: %s - Plugin name
 #. translators: Placeholder: %s - Payment gateway title (e.g. Authorize.Net, Braintree, etc.)
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php:225
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:211
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php:225
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:211
 msgid "%s Payment Tokens"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php:303
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:874
+#: payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php:303
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:878
 msgid "Customer ID"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:32
+#: payment-gateway/admin/views/html-admin-gateway-status.php:32
 msgid "This section contains configuration settings for this gateway."
 msgstr ""
 
 #. translators: environment as in a software environment (test/production)
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:53
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1419
+#: payment-gateway/admin/views/html-admin-gateway-status.php:53
+#: payment-gateway/class-sv-wc-payment-gateway.php:1419
 msgid "Environment"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:54
+#: payment-gateway/admin/views/html-admin-gateway-status.php:54
 msgid "The transaction environment for this gateway."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:61
+#: payment-gateway/admin/views/html-admin-gateway-status.php:61
 msgid "Tokenization Enabled"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:62
+#: payment-gateway/admin/views/html-admin-gateway-status.php:62
 msgid "Displays whether or not tokenization is enabled for this gateway."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:75
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1346
+#: payment-gateway/admin/views/html-admin-gateway-status.php:75
+#: payment-gateway/class-sv-wc-payment-gateway.php:1346
 msgid "Debug Mode"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:76
+#: payment-gateway/admin/views/html-admin-gateway-status.php:76
 msgid "Displays whether or not debug logging is enabled for this gateway."
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:79
+#: payment-gateway/admin/views/html-admin-gateway-status.php:79
 msgid "Display at Checkout & Log"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:81
+#: payment-gateway/admin/views/html-admin-gateway-status.php:81
 msgid "Display at Checkout"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:83
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1354
+#: payment-gateway/admin/views/html-admin-gateway-status.php:83
+#: payment-gateway/class-sv-wc-payment-gateway.php:1354
 msgid "Save to Log"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-admin-gateway-status.php:85
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1352
+#: payment-gateway/admin/views/html-admin-gateway-status.php:85
+#: payment-gateway/class-sv-wc-payment-gateway.php:1352
 msgid "Off"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-order-partial-capture.php:30
+#: payment-gateway/admin/views/html-order-partial-capture.php:30
 msgctxt "Authorized transaction for order payment"
 msgid "Authorization total"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-order-partial-capture.php:34
+#: payment-gateway/admin/views/html-order-partial-capture.php:34
 msgctxt "Captured transaction (without charge) for order payment"
 msgid "Amount already captured"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-order-partial-capture.php:40
+#: payment-gateway/admin/views/html-order-partial-capture.php:40
 msgid "Remaining order total"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-order-partial-capture.php:46
+#: payment-gateway/admin/views/html-order-partial-capture.php:46
 msgctxt "Capture (without charge) amount for order payment"
 msgid "Capture amount"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-order-partial-capture.php:53
+#: payment-gateway/admin/views/html-order-partial-capture.php:53
 msgid "Comment (optional):"
 msgstr ""
 
 #. translators: Context: Capture payment without charge. Placeholder: %s - transaction amount to be captured.
-#: woocommerce/payment-gateway/admin/views/html-order-partial-capture.php:67
+#: payment-gateway/admin/views/html-order-partial-capture.php:67
 msgid "Capture %s"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-order-partial-capture.php:70
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:608
+#: payment-gateway/admin/views/html-order-partial-capture.php:70
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:608
 msgid "Cancel"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-user-payment-token-editor-token.php:57
+#: payment-gateway/admin/views/html-user-payment-token-editor-token.php:57
 msgid "-- Select an option --"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-user-payment-token-editor.php:59
+#: payment-gateway/admin/views/html-user-payment-token-editor.php:59
 msgid "No saved payment tokens"
 msgstr ""
 
-#: woocommerce/payment-gateway/admin/views/html-user-profile-field-customer-id.php:30
+#: payment-gateway/admin/views/html-user-profile-field-customer-id.php:30
 msgid "The gateway customer ID for the user. Only edit this if necessary."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:99
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php:141
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Frontend.php:131
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:99
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php:141
+#: payment-gateway/External_Checkout/Google_Pay/Frontend.php:131
 msgid "An error occurred, please try again or try an alternate form of payment"
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:100
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:100
 msgid "We cannot process your order with the payment information that you provided. Please use a different payment account or an alternate payment method."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:101
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:101
 msgid "This order is being placed on hold for review. Please contact us to complete the transaction."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:106
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:106
 msgctxt "Credit or debit card CSC/CVC/CVV"
 msgid "This order is being placed on hold for review due to an incorrect card verification number. You may contact the store to complete the transaction."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:107
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:107
 msgctxt "Credit or debit card CSC/CVC/CVV"
 msgid "The card verification number is invalid, please try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:108
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:108
 msgctxt "Credit or debit card CSC/CVC/CVV"
 msgid "Please enter your card verification number and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:111
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:111
 msgctxt "Credit or debit card"
 msgid "That card type is not accepted, please use an alternate card or other form of payment."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:112
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:116
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:112
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:116
 msgctxt "Credit or debit card"
 msgid "The card type is invalid or does not correlate with the credit card number. Please try again or use an alternate card or other form of payment."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:113
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:113
 msgctxt "Credit or debit card"
 msgid "Please select the card type and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:117
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:117
 msgctxt "Credit or debit card"
 msgid "The card number is invalid, please re-enter and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:118
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:118
 msgctxt "Credit or debit card"
 msgid "Please enter your card number and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:121
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:121
 msgctxt "Credit or debit card (whole date issue)"
 msgid "The card expiration date is invalid, please re-enter and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:122
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:122
 msgctxt "Credit or debit card"
 msgid "The card expiration month is invalid, please re-enter and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:123
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:123
 msgctxt "Credit or debit card"
 msgid "The card expiration year is invalid, please re-enter and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:124
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:124
 msgctxt "Credit or debit card"
 msgid "Please enter your card expiration date and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:127
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:127
 msgid "The bank routing number is invalid, please re-enter and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:128
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:128
 msgid "The bank account number is invalid, please re-enter and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:131
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:131
 msgctxt "Credit or debit card"
 msgid "The provided card is expired, please use an alternate card or other form of payment."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:132
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:132
 msgctxt "Credit or debit card"
 msgid "The provided card was declined, please use an alternate card or other form of payment."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:133
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:133
 msgctxt "Credit or debit card"
 msgid "Insufficient funds in account, please use an alternate card or other form of payment."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:134
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:134
 msgctxt "Credit or debit card"
 msgid "The card is inactivate or not authorized for card-not-present transactions, please use an alternate card or other form of payment."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:135
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:135
 msgctxt "Credit or debit card"
 msgid "The credit limit for the card has been reached, please use an alternate card or other form of payment."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:136
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:136
 msgctxt "Credit or debit card CSC/CVC/CVV"
 msgid "The card verification number does not match. Please re-enter and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:137
+#: payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php:137
 msgctxt "Credit or debit card"
 msgid "The provided address does not match the billing address for cardholder. Please verify the address and try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:61
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:61
 msgid "Payment error, please try another payment method or contact us to complete your transaction."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:161
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:161
 msgid "Card expiration date is invalid"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:185
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:185
 msgid "Card number is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:191
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:191
 msgid "Card number is invalid (wrong length)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:196
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:196
 msgid "Card number is invalid (only digits allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:201
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:201
 msgid "Card number is invalid"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:228
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:228
 msgid "Card security code is invalid (only digits are allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:234
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:234
 msgid "Card security code is invalid (must be 3 or 4 digits)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:240
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:240
 msgid "Card security code is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:267
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:267
 msgid "Routing Number is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:274
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:274
 msgid "Routing Number is invalid (only digits are allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:280
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:280
 msgid "Routing number is invalid (must be 9 digits)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:289
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:289
 msgid "Account Number is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:296
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:296
 msgid "Account Number is invalid (only digits are allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:302
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:302
 msgctxt "Bank account"
 msgid "Account number is invalid (must be between 5 and 17 digits)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:309
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:507
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:309
+#: payment-gateway/class-sv-wc-payment-gateway.php:507
 msgid "Driver's license number is invalid"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:315
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:503
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:315
+#: payment-gateway/class-sv-wc-payment-gateway.php:503
 msgctxt "Bank check (noun)"
 msgid "Check Number is invalid (only digits are allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:493
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:493
 msgid "Unknown error"
 msgstr ""
 
 #. translators: Placeholder: %s - Error message
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:503
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:503
 msgid "Payment method address could not be updated. %s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - Payment method title, %2$s - Payment account type (savings/checking) (may or may not be available), %3$s - Last four digits of the account
 #. translators: Context: "Check" as in "bank check" (noun, not verb). Placeholders: %1$s - payment method title, %2$s - payment account type (savings/checking) (may or may not be available), %3$s - last four digits of the account
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:673
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2783
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:673
+#: payment-gateway/class-sv-wc-payment-gateway.php:2783
 msgid "%1$s Check Transaction Approved: %2$s account ending in %3$s"
 msgstr ""
 
 #. translators: Placeholder: %s - Bank check number
 #. translators: Context: "Check" as in "bank check" (noun, not verb). Placeholder: %s - check number
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:678
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2788
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:678
+#: payment-gateway/class-sv-wc-payment-gateway.php:2788
 msgid "Check number %s"
 msgstr ""
 
 #. translators: Placeholder: %s - Payment transaction ID
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:684
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:781
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2196
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2429
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2748
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2794
-#: woocommerce/payment-gateway/Handlers/Capture.php:199
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:365
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:684
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:781
+#: payment-gateway/class-sv-wc-payment-gateway.php:2196
+#: payment-gateway/class-sv-wc-payment-gateway.php:2429
+#: payment-gateway/class-sv-wc-payment-gateway.php:2748
+#: payment-gateway/class-sv-wc-payment-gateway.php:2794
+#: payment-gateway/Handlers/Capture.php:199
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:365
 msgid "(Transaction ID %s)"
 msgstr ""
 
 #. translators: Example: "Braintree Test Authorization Approved: Mastercard ending in 1234". Placeholders: %1$s - payment method title, %2$s - environment ("Test"), %3$s - transaction type (authorization/charge), %4$s - card type (mastercard, visa, ...), %5$s - last four digits of the card
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:750
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:750
 msgid "%1$s %2$s %3$s Approved: %4$s ending in %5$s"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:752
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:762
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:752
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:762
 msgctxt "Noun, software environment"
 msgid "Test"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:753
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:763
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:753
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:763
 msgctxt "Credit card transaction type"
 msgid "Authorization"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:753
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:763
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2722
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3203
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:753
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:763
+#: payment-gateway/class-sv-wc-payment-gateway.php:2722
+#: payment-gateway/class-sv-wc-payment-gateway.php:3203
 msgctxt "noun, credit card transaction type"
 msgid "Charge"
 msgstr ""
 
 #. translators: Example: "Authorize.Net Test Charge Approved: Mastercard" - Placeholders: %1$s - payment method title, %2$s - environment ("Test"), %3$s - transaction type (authorization/charge), %4$s - card type (mastercard, visa, ...)
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:760
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:760
 msgid "%1$s %2$s %3$s Approved: %4$s"
 msgstr ""
 
 #. translators: Placeholder: %s - Credit card expiry date
 #. translators: Placeholders: %s - expiry date
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:773
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:718
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2740
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:773
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:718
+#: payment-gateway/class-sv-wc-payment-gateway.php:2740
 msgid "(expires %s)"
 msgstr ""
 
 #. translators: Placeholders: %s - failure message
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:843
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:843
 msgid "Tokenization Request Failed: %s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment method title, %2$s - failure message
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:854
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:854
 msgid "%1$s Tokenization Request Failed: %2$s"
 msgstr ""
 
 #. translators: This is a message describing that the transaction in question only performed a credit card authorization and did not capture any funds.
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:875
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1895
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:275
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:382
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:875
+#: payment-gateway/class-sv-wc-payment-gateway.php:1895
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:275
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:382
 msgid "Authorization only transaction"
 msgstr ""
 
 #. translators: Placeholders: %s - failure message. Payment method as in a specific credit card, e-check or bank account
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:912
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:912
 msgid "Oops, adding your new payment method failed: %s"
 msgstr ""
 
 #. translators: Payment method as in a specific credit card. Placeholders: %1$s - card type (visa, mastercard, ...), %2$s - last four digits of the card, %3$s - card expiry date
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:957
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:957
 msgid "Nice! New payment method added: %1$s ending in %2$s (expires %3$s)"
 msgstr ""
 
 #. translators: Payment method as in a specific e-check account. Placeholders: %1$s - account type (checking/savings), %2$s - last four digits of the account
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:967
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:967
 msgid "Nice! New payment method added: %1$s account ending in %2$s"
 msgstr ""
 
 #. translators: Payment method as in a specific credit card, e-check or bank account
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:974
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:974
 msgid "Nice! New payment method added."
 msgstr ""
 
 #. translators: Placeholders: %1$s - site title, %2$s - customer email. Payment method as in a specific credit card, e-check or bank account
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php:1097
+#: payment-gateway/class-sv-wc-payment-gateway-direct.php:1097
 msgid "%1$s - Add Payment Method for %2$s"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:178
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:178
 msgid "PayPal"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:179
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:179
 msgid "Checking Account"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:180
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:180
 msgid "Savings Account"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:181
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:181
 msgid "Credit / Debit Card"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:182
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:182
 msgid "Bank Account"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:191
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:191
 msgctxt "payment method type"
 msgid "Account"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:227
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3462
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:227
+#: payment-gateway/class-sv-wc-payment-gateway.php:3462
 msgctxt "credit card type"
 msgid "Visa"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:231
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3463
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:231
+#: payment-gateway/class-sv-wc-payment-gateway.php:3463
 msgctxt "credit card type"
 msgid "MasterCard"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:235
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3464
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:235
+#: payment-gateway/class-sv-wc-payment-gateway.php:3464
 msgctxt "credit card type"
 msgid "American Express"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:239
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:239
 msgctxt "credit card type"
 msgid "Diners Club"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:243
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3465
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:243
+#: payment-gateway/class-sv-wc-payment-gateway.php:3465
 msgctxt "credit card type"
 msgid "Discover"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:247
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3467
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:247
+#: payment-gateway/class-sv-wc-payment-gateway.php:3467
 msgctxt "credit card type"
 msgid "JCB"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:251
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:251
 msgctxt "credit card type"
 msgid "CarteBleue"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:255
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:255
 msgctxt "credit card type"
 msgid "Maestro"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php:259
+#: payment-gateway/class-sv-wc-payment-gateway-helper.php:259
 msgctxt "credit card type"
 msgid "Laser"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:301
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:301
 msgid "Thank you for your order, please click the button below to pay."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:302
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:302
 msgid "Thank you for your order. We are now redirecting you to complete payment."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:303
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:303
 msgid "Pay Now"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:304
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:304
 msgid "Cancel Order"
 msgstr ""
 
 #. translators: Placeholders: %s - a WooCommerce order ID
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:449
-#: woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php:320
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:449
+#: payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php:320
 msgid "Could not find order %s"
 msgstr ""
 
 #. translators: Placeholders: %s - payment gateway title (such as Authorize.net, Braintree, etc)
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:513
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:205
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:513
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:205
 msgid "%s duplicate transaction received"
 msgstr ""
 
 #. translators: Placeholder: %s - Order number
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:517
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:208
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:517
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:208
 msgid "Order %s is already paid for."
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title (such as Authorize.net, Braintree, etc), %2$s - payment method name (mastercard, bank account, etc), %3$s - last four digits of the card/account, %4$s - card/account expiry date
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:602
-#: woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:1121
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:602
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:1121
 msgid "%1$s Payment Method Saved: %2$s ending in %3$s (expires %4$s)"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title (such as CyberSouce, NETbilling, etc), %2$s - account type (checking/savings - may or may not be available), %3$s - last four digits of the account
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:613
-#: woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:1132
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:613
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:1132
 msgid "%1$s eCheck Payment Method Saved: %2$s account ending in %3$s"
 msgstr ""
 
 #. translators: Placeholders: %s - payment gateway title (such as CyberSouce, NETbilling, etc)
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:622
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:622
 msgid "%s Payment Method Saved"
 msgstr ""
 
 #. translators: Placeholders: %s - a failed tokenization API error
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php:631
+#: payment-gateway/class-sv-wc-payment-gateway-hosted.php:631
 msgid "Tokenization failed. %s"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:293
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:607
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:293
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:607
 msgid "Edit"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:337
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1299
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:337
+#: payment-gateway/class-sv-wc-payment-gateway.php:1299
 msgid "Title"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:340
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:340
 msgid "Details"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:343
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:343
 msgid "Default?"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:609
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:609
 msgid "Oops, there was an error updating your payment method. Please try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:610
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:610
 msgid "Are you sure you want to delete this payment method?"
 msgstr ""
 
 #. translators: Payment method as in a specific credit card, eCheck or bank account
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:697
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:697
 msgid "You do not have any saved payment methods."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:872
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:201
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:872
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:201
 msgid "Nickname"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1118
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1118
 msgid "Oops, you took too long, please try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1129
+#: payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php:1129
 msgid "There was an error with your request, please try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:344
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:344
 msgid "Card Number"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:365
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:365
 msgid "MM / YY"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:384
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:384
 msgid "Card Security Code"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:387
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:387
 msgid "CSC"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:427
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:427
 msgid "Where do I find this?"
 msgstr ""
 
 #. translators: e-check routing number, HTML form field label, https://en.wikipedia.org/wiki/Routing_transit_number
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:433
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:433
 msgid "Routing Number"
 msgstr ""
 
 #. translators: e-check account number, HTML form field label
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:452
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:452
 msgid "Account Number"
 msgstr ""
 
 #. translators: http://www.investopedia.com/terms/c/checkingaccount.asp
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:478
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:478
 msgctxt "account type"
 msgid "Checking"
 msgstr ""
 
 #. translators: http://www.investopedia.com/terms/s/savingsaccount.asp
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:480
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:480
 msgctxt "account type"
 msgid "Savings"
 msgstr ""
 
 #. translators: Test mode refers to the current software environment
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:518
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:518
 msgid "TEST MODE ENABLED"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:545
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:545
 msgctxt "Bank check (noun)"
 msgid "Sample Check"
 msgstr ""
 
 #. translators: Payment method as in a specific credit card, eCheck or bank account
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:620
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:620
 msgid "Manage Payment Methods"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:757
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:757
 msgid "Use a new card"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:757
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:757
 msgid "Use a new bank account"
 msgstr ""
 
 #. translators: account as in customer's account on the eCommerce site
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:820
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:820
 msgid "Securely Save to Account"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php:954
+#: payment-gateway/class-sv-wc-payment-gateway-payment-form.php:954
 msgid "Payment Info"
 msgstr ""
 
 #. translators: Placeholders: %1$s - plugin name, %2$s - <a> tag, %3$s - </a> tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:706
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:706
 msgid "%1$s: WooCommerce is not being forced over SSL; your customers' payment data may be at risk. %2$sVerify your site URLs here%3$s"
 msgstr ""
 
 #. translators: Placeholders: %s - payment gateway name
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:723
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:723
 msgid "%s will soon require TLS 1.2 support to process transactions and your server environment may need to be updated. Please contact your hosting provider to confirm that your site can send and receive TLS 1.2 connections and request they make any necessary updates."
 msgstr ""
 
 #. translators: Placeholders: %1$s - plugin name, %2$s - a currency/comma-separated list of currencies, %3$s - <a> tag, %4$s - </a> tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:778
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:778
 msgid "%1$s accepts payment in %2$s only. %3$sConfigure%4$s WooCommerce to accept %2$s to enable this gateway for checkout."
 msgid_plural "%1$s accepts payment in one of %2$s only. %3$sConfigure%4$s WooCommerce to accept one of %2$s to enable this gateway for checkout."
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: Placeholders: %1$s - payment gateway name, %2$s - opening <a> tag, %3$s - closing </a> tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:808
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:808
 msgid "Heads up! %1$s is currently configured to log transaction data for debugging purposes. If you are not experiencing any problems with payment processing, we recommend %2$sturning off Debug Mode%3$s"
 msgstr ""
 
 #. translators: Placeholders: %s - gateway name
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:859
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:859
 msgid "%s is not configured"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:871
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:871
 msgid "Dismiss"
 msgstr ""
 
 #. translators: Placeholders: %1$s - plugin name, %2$s - opening <a> HTML link tag, %3$s - closing </a> HTML link tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:908
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:908
 msgid "Heads up! Apple Pay for %1$s requires WooCommerce version 3.2 or greater. Please %2$supdate WooCommerce%3$s."
 msgstr ""
 
 #. translators: Placeholders: %1$s - plugin name, %2$s - opening <a> HTML link tag, %3$s - closing </a> HTML link tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:932
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:932
 msgid "Heads up! Google Pay for %1$s requires WooCommerce version 3.2 or greater. Please %2$supdate WooCommerce%3$s."
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title (such as Authorize.net, Braintree, etc), %2$s - <a> tag, %3$s - </a> tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:968
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:968
 msgid "%1$s is inactive for subscription transactions. Please %2$senable tokenization%3$s to activate %1$s for Subscriptions."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:986
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:986
 msgid "%1$s is inactive for pre-order transactions. Please %2$senable tokenization%3$s to activate %1$s for Pre-Orders."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:1023
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:1023
 msgid "You must enable tokenization for this gateway in order to support automatic renewal payments with the WooCommerce Subscriptions extension."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php:1024
+#: payment-gateway/class-sv-wc-payment-gateway-plugin.php:1024
 msgid "Inactive"
 msgstr ""
 
 #. translators: Placeholder: %s - Payment gateway title (e.g. Authorize.Net, Braintree...)
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:116
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:116
 msgid "%s Customer ID"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:185
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:185
 msgid "Type"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:256
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:256
 msgid "Removed payment token \"%d\""
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php:303
+#: payment-gateway/class-sv-wc-payment-gateway-privacy.php:303
 msgid "Expiry Date"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:350
+#: payment-gateway/class-sv-wc-payment-gateway.php:350
 msgctxt "Congratulatory message displayed to the merchant when they process their first payment"
 msgid "You successfully processed a payment!"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:355
+#: payment-gateway/class-sv-wc-payment-gateway.php:355
 msgctxt "Congratulatory message displayed to the merchant when they process their first refund"
 msgid "You successfully processed a refund!"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:495
+#: payment-gateway/class-sv-wc-payment-gateway.php:495
 msgctxt "Credit or debit card"
 msgid "Card number is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:496
+#: payment-gateway/class-sv-wc-payment-gateway.php:496
 msgctxt "Credit or debit card"
 msgid "Card number is invalid"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:497
+#: payment-gateway/class-sv-wc-payment-gateway.php:497
 msgctxt "Credit or debit card"
 msgid "Card number is invalid (only digits allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:498
+#: payment-gateway/class-sv-wc-payment-gateway.php:498
 msgctxt "Credit or debit card"
 msgid "Card number is invalid (wrong length)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:499
+#: payment-gateway/class-sv-wc-payment-gateway.php:499
 msgctxt "Credit or debit card"
 msgid "Card security code is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:500
+#: payment-gateway/class-sv-wc-payment-gateway.php:500
 msgctxt "Credit or debit card"
 msgid "Card security code is invalid (only digits are allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:501
+#: payment-gateway/class-sv-wc-payment-gateway.php:501
 msgctxt "Credit or debit card"
 msgid "Card security code is invalid (must be 3 or 4 digits)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:502
+#: payment-gateway/class-sv-wc-payment-gateway.php:502
 msgctxt "Credit or debit card"
 msgid "Card expiration date is invalid"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:504
+#: payment-gateway/class-sv-wc-payment-gateway.php:504
 msgctxt "Bank check (noun)"
 msgid "Check Number is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:505
+#: payment-gateway/class-sv-wc-payment-gateway.php:505
 msgctxt "For countries without states, \"state\" can be replaced with \"place of issue\"."
 msgid "Driver's license state is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:506
+#: payment-gateway/class-sv-wc-payment-gateway.php:506
 msgid "Driver's license number is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:508
+#: payment-gateway/class-sv-wc-payment-gateway.php:508
 msgctxt "Bank account"
 msgid "Account Number is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:509
+#: payment-gateway/class-sv-wc-payment-gateway.php:509
 msgctxt "Bank account"
 msgid "Account Number is invalid (only digits are allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:510
+#: payment-gateway/class-sv-wc-payment-gateway.php:510
 msgctxt "Bank account"
 msgid "Account Number is invalid (must be between 5 and 17 digits)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:511
+#: payment-gateway/class-sv-wc-payment-gateway.php:511
 msgctxt "Bank account"
 msgid "Routing Number is missing"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:512
+#: payment-gateway/class-sv-wc-payment-gateway.php:512
 msgctxt "Bank account"
 msgid "Routing Number is invalid (only digits are allowed)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:513
+#: payment-gateway/class-sv-wc-payment-gateway.php:513
 msgctxt "Bank account"
 msgid "Routing Number is invalid (must be 9 digits)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:719
+#: payment-gateway/class-sv-wc-payment-gateway.php:719
 msgid "Continue to Payment"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:719
+#: payment-gateway/class-sv-wc-payment-gateway.php:719
 msgid "Place order"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:751
+#: payment-gateway/class-sv-wc-payment-gateway.php:751
 msgid "Thank you for your order."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1251
+#: payment-gateway/class-sv-wc-payment-gateway.php:1251
 msgid "Credit Card"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1253
+#: payment-gateway/class-sv-wc-payment-gateway.php:1253
 msgid "eCheck"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1271
+#: payment-gateway/class-sv-wc-payment-gateway.php:1271
 msgid "Pay securely using your credit card."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1273
+#: payment-gateway/class-sv-wc-payment-gateway.php:1273
 msgid "Pay securely using your checking account."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1292
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:93
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:93
+#: payment-gateway/class-sv-wc-payment-gateway.php:1292
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:93
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:93
 msgid "Enable / Disable"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1293
+#: payment-gateway/class-sv-wc-payment-gateway.php:1293
 msgid "Enable this gateway"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1301
+#: payment-gateway/class-sv-wc-payment-gateway.php:1301
 msgid "Payment method title that the customer will see during checkout."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1306
+#: payment-gateway/class-sv-wc-payment-gateway.php:1306
 msgid "Description"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1308
+#: payment-gateway/class-sv-wc-payment-gateway.php:1308
 msgid "Payment method description that the customer will see during checkout."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1337
+#: payment-gateway/class-sv-wc-payment-gateway.php:1337
 msgid "Detailed Decline Messages"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1339
+#: payment-gateway/class-sv-wc-payment-gateway.php:1339
 msgid "Check to enable detailed decline messages to the customer during checkout when possible, rather than a generic decline message."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1349
+#: payment-gateway/class-sv-wc-payment-gateway.php:1349
 msgid "Show Detailed Error Messages and API requests/responses on the checkout page and/or save them to the %1$sdebug log%2$s"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1353
+#: payment-gateway/class-sv-wc-payment-gateway.php:1353
 msgid "Show on Checkout Page"
 msgstr ""
 
 #. translators: show debugging information on both checkout page and in the log
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1356
+#: payment-gateway/class-sv-wc-payment-gateway.php:1356
 msgid "Both"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1422
+#: payment-gateway/class-sv-wc-payment-gateway.php:1422
 msgid "Select the gateway environment to use for transactions."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1470
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:151
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:149
+#: payment-gateway/class-sv-wc-payment-gateway.php:1470
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:151
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:149
 msgid "Connection Settings"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1476
+#: payment-gateway/class-sv-wc-payment-gateway.php:1476
 msgid "Share connection settings"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1478
+#: payment-gateway/class-sv-wc-payment-gateway.php:1478
 msgid "Use connection/authentication settings from other gateway"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1481
+#: payment-gateway/class-sv-wc-payment-gateway.php:1481
 msgid "Disabled because the other gateway is using these settings"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1498
+#: payment-gateway/class-sv-wc-payment-gateway.php:1498
 msgid "Card Security Code (CSC)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1499
+#: payment-gateway/class-sv-wc-payment-gateway.php:1499
 msgid "Display the Card Security Code (CSC) field on checkout"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1507
+#: payment-gateway/class-sv-wc-payment-gateway.php:1507
 msgid "Saved Card Security Code"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1508
+#: payment-gateway/class-sv-wc-payment-gateway.php:1508
 msgid "Display the Card Security Code field when paying with a saved card"
 msgstr ""
 
 #. translators: Placeholders: %1$s - site title, %2$s - order number
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1843
+#: payment-gateway/class-sv-wc-payment-gateway.php:1843
 msgid "%1$s - Order %2$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - site title, %2$s - order number. Definitions: Capture as in capture funds from a credit card.
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:1977
+#: payment-gateway/class-sv-wc-payment-gateway.php:1977
 msgid "%1$s - Capture for Order %2$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - site title, %2$s - order number
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2120
+#: payment-gateway/class-sv-wc-payment-gateway.php:2120
 msgid "%1$s - Refund for Order %2$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title (such as Authorize.net, Braintree, etc), %2$s - a monetary amount
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2187
+#: payment-gateway/class-sv-wc-payment-gateway.php:2187
 msgid "%1$s Refund in the amount of %2$s approved."
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title (such as Authorize.net, Braintree, etc), %2$s - error code, %3$s - error message
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2217
+#: payment-gateway/class-sv-wc-payment-gateway.php:2217
 msgid "%1$s Refund Failed: %2$s - %3$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title (such as Authorize.net, Braintree, etc), %2$s - error message
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2225
+#: payment-gateway/class-sv-wc-payment-gateway.php:2225
 msgid "%1$s Refund Failed: %2$s"
 msgstr ""
 
 #. translators: Placeholders: %s - payment gateway title (such as Authorize.net, Braintree, etc)
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2246
+#: payment-gateway/class-sv-wc-payment-gateway.php:2246
 msgid "%s Order completely refunded."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2301
+#: payment-gateway/class-sv-wc-payment-gateway.php:2301
 msgid "Oops, you cannot partially void this order. Please use the full order amount."
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title, %2$s - error code, %3$s - error message. Void as in to void an order.
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2388
+#: payment-gateway/class-sv-wc-payment-gateway.php:2388
 msgid "%1$s Void Failed: %2$s - %3$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title, %2$s - error message. Void as in to void an order.
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2396
+#: payment-gateway/class-sv-wc-payment-gateway.php:2396
 msgid "%1$s Void Failed: %2$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title, %2$s - a monetary amount. Void as in to void an order.
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2420
+#: payment-gateway/class-sv-wc-payment-gateway.php:2420
 msgid "%1$s Void in the amount of %2$s approved."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2495
+#: payment-gateway/class-sv-wc-payment-gateway.php:2495
 msgctxt "hash before order number"
 msgid "#"
 msgstr ""
 
 #. translators: Placeholders: %1$s - status code, %2$s - status message
 #. translators: Placeholders: %1$s - Payment request response status code, %2$s - Payment request response status message
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2517
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:152
-#: woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:178
+#: payment-gateway/class-sv-wc-payment-gateway.php:2517
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:152
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:178
 msgid "Status code %1$s: %2$s"
 msgstr ""
 
 #. translators: Placeholders: %s - status code
 #. translators: Placeholder: %s - Payment request response status code
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2520
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:155
-#: woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:181
+#: payment-gateway/class-sv-wc-payment-gateway.php:2520
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:155
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:181
 msgid "Status code: %s"
 msgstr ""
 
 #. translators: Placeholders; %s - status message
 #. translators: Placeholder: %s - Status message
 #. translators: Placeholder: %s - Payment request response status message
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2523
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:158
-#: woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:184
+#: payment-gateway/class-sv-wc-payment-gateway.php:2523
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:158
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:184
 msgid "Status message: %s"
 msgstr ""
 
 #. translators: Placeholder: %s - Payment transaction ID
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2528
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:164
-#: woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:192
+#: payment-gateway/class-sv-wc-payment-gateway.php:2528
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:164
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:192
 msgid "Transaction ID %s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment method title, %2$s - environment ("Test"), %3$s - transaction type (authorization/charge)
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2719
+#: payment-gateway/class-sv-wc-payment-gateway.php:2719
 msgid "%1$s %2$s %3$s Approved"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2721
+#: payment-gateway/class-sv-wc-payment-gateway.php:2721
 msgctxt "noun, software environment"
 msgid "Test"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2722
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3204
+#: payment-gateway/class-sv-wc-payment-gateway.php:2722
+#: payment-gateway/class-sv-wc-payment-gateway.php:3204
 msgctxt "credit card transaction type"
 msgid "Authorization"
 msgstr ""
 
 #. translators: Placeholders: %1$s - credit card type (MasterCard, Visa, etc...), %2$s - last four digits of the card
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2729
+#: payment-gateway/class-sv-wc-payment-gateway.php:2729
 msgid "%1$s ending in %2$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title, %2$s - message (probably reason for the transaction being held for review)
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2826
+#: payment-gateway/class-sv-wc-payment-gateway.php:2826
 msgid "%1$s Transaction Held for Review (%2$s)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2868
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:268
+#: payment-gateway/class-sv-wc-payment-gateway.php:2868
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:268
 msgid "Your order has been received and is being reviewed. Thank you for your business."
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title, %2$s - error message; e.g. Order Note: [Payment method] Payment failed [error]
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2915
+#: payment-gateway/class-sv-wc-payment-gateway.php:2915
 msgid "%1$s Payment Failed (%2$s)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2932
-#: woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php:217
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:526
+#: payment-gateway/class-sv-wc-payment-gateway.php:2932
+#: payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php:217
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:530
 msgid "An error occurred, please try again or try an alternate form of payment."
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title, %2$s - message/error
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:2950
+#: payment-gateway/class-sv-wc-payment-gateway.php:2950
 msgid "%1$s Transaction Cancelled (%2$s)"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3198
+#: payment-gateway/class-sv-wc-payment-gateway.php:3198
 msgid "Transaction Type"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3200
+#: payment-gateway/class-sv-wc-payment-gateway.php:3200
 msgid "Select how transactions should be processed. Charge submits all transactions for settlement, Authorization simply authorizes the order total for capture later."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3211
+#: payment-gateway/class-sv-wc-payment-gateway.php:3211
 msgid "Charge Virtual-Only Orders"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3213
+#: payment-gateway/class-sv-wc-payment-gateway.php:3213
 msgid "If the order contains exclusively virtual items, enable this to immediately charge, rather than authorize, the transaction."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3221
+#: payment-gateway/class-sv-wc-payment-gateway.php:3221
 msgid "Enable Partial Capture"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3223
+#: payment-gateway/class-sv-wc-payment-gateway.php:3223
 msgid "Allow orders to be partially captured multiple times."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3232
+#: payment-gateway/class-sv-wc-payment-gateway.php:3232
 msgctxt "coordinating conjunction for a list of order statuses: on-hold, processing, or completed"
 msgid "or"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3235
+#: payment-gateway/class-sv-wc-payment-gateway.php:3235
 msgid "Capture Paid Orders"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3238
+#: payment-gateway/class-sv-wc-payment-gateway.php:3238
 msgid "Automatically capture orders when they are changed to %s."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3239
+#: payment-gateway/class-sv-wc-payment-gateway.php:3239
 msgid "a paid status"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3429
+#: payment-gateway/class-sv-wc-payment-gateway.php:3429
 msgid "Accepted Card Logos"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3431
+#: payment-gateway/class-sv-wc-payment-gateway.php:3431
 msgid "These are the card logos that are displayed to customers as accepted during checkout."
 msgstr ""
 
 #. translators: Placeholders: %1$s - <strong> tag, %2$s - </strong> tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3434
+#: payment-gateway/class-sv-wc-payment-gateway.php:3434
 msgid "This setting %1$sdoes not%2$s change which card types the gateway will accept. Accepted cards are configured from your payment processor account."
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3466
+#: payment-gateway/class-sv-wc-payment-gateway.php:3466
 msgctxt "credit card type"
 msgid "Diners"
 msgstr ""
 
 #. translators: http://www.cybersource.com/products/payment_security/payment_tokenization/ and https://en.wikipedia.org/wiki/Tokenization_(data_security)
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3525
+#: payment-gateway/class-sv-wc-payment-gateway.php:3525
 msgid "Tokenization"
 msgstr ""
 
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:3526
+#: payment-gateway/class-sv-wc-payment-gateway.php:3526
 msgid "Allow customers to securely save their payment details for future checkout."
 msgstr ""
 
 #. translators: https://www.skyverge.com/for-translators-environments
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:4037
+#: payment-gateway/class-sv-wc-payment-gateway.php:4037
 msgctxt "software environment"
 msgid "Production"
 msgstr ""
 
 #. translators: %1$s - gateway name, %2$s - <a> tag, %3$s - </a> tag, %4$s - <a> tag, %5$s - </a> tag
-#: woocommerce/payment-gateway/class-sv-wc-payment-gateway.php:4311
+#: payment-gateway/class-sv-wc-payment-gateway.php:4311
 msgid "Heads up! %1$s is not fully configured and cannot accept payments. Please %2$sreview the documentation%3$s and configure the %4$sgateway settings%5$s."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:137
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:147
+#: payment-gateway/External_Checkout/Admin.php:137
+#: payment-gateway/External_Checkout/Admin.php:147
 msgctxt "Noun: payment gateway used to process a transaction"
 msgid "Processing Gateway"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:287
+#: payment-gateway/External_Checkout/Admin.php:287
 msgid "Single products"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:288
+#: payment-gateway/External_Checkout/Admin.php:288
 msgid "Cart"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:289
+#: payment-gateway/External_Checkout/Admin.php:289
 msgid "Checkout"
 msgstr ""
 
 #. translators: Placeholder: %s - external checkout label
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:330
+#: payment-gateway/External_Checkout/Admin.php:330
 msgid "%s is disabled."
 msgstr ""
 
 #. translators: Context: Error message displayed to merchants if their store currency is not in one of the accepted currencies by the payment gateway they intend to enable. Placeholders: %1$s - a currency or comma-separated list of currencies, %2$s - opening HTML <a> tag, %3$s - closing HTML </a> tag, %4$s - payment method title/label
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:394
+#: payment-gateway/External_Checkout/Admin.php:394
 msgid "Accepts payment in %1$s only. %2$sConfigure%3$s WooCommerce to accept %1$s to enable %4$s."
 msgid_plural "Accepts payment in %1$s only. %2$sConfigure%3$s WooCommerce to accept %1$s to enable %4$s."
 msgstr[0] ""
 msgstr[1] ""
 
 #. translators: Placeholders: %1$s - Checkout method label, %2$s - Opening HTML <a> tag, %3$s - Closing HTML </a> tag, %4$s - Opening HTML <strong> tag, %5$s - closing HTML </strong> tag
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:431
+#: payment-gateway/External_Checkout/Admin.php:431
 msgid "Your store %1$scalculates taxes%2$s based on the shipping address, but %1$s %4$sdoes not%5$s share customer shipping information with your store for orders with only virtual products. These orders will have their taxes calculated based on the shop address instead."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Admin.php:464
+#: payment-gateway/External_Checkout/Admin.php:464
 msgid "%4$s%1$s Notice!%5$s Your store %2$scalculates taxes%3$s based on the billing address, but %1$s %4$sdoes not%5$s share the customer billing address with your store before payment. These orders will have their taxes calculated based on the shipping address (or shop address, for orders with only virtual products)."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:71
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:87
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:65
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:71
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:87
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:65
 msgid "Apple Pay"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:94
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:94
 msgctxt "For the merchant to accept Apple Pay payments"
 msgid "Accept Apple Pay"
 msgstr ""
 
 #. translators: Allow Apple Pay button on selected display locations (e.g. cart, checkout, product page...)
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:102
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:102
 msgid "Allow Apple Pay on"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:112
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:112
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:112
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:112
 msgid "Button Style"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:115
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:115
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:115
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:115
 msgctxt "Button style"
 msgid "Black"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:116
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:116
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:116
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:116
 msgctxt "Button style"
 msgid "White"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:117
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:117
 msgctxt "Button style"
 msgid "White with outline"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:160
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:160
 msgid "Apple Merchant ID"
 msgstr ""
 
 #. translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:164
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:164
 msgid "This is found in your %1$sApple developer account%2$s"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:174
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:174
 msgid "Certificate Path"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:176
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:176
 msgid "The full system path to your certificate file from Apple. For security reasons you should store this outside of your web root."
 msgstr ""
 
 #. translators: Placeholders: %s - the server's web root path
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:179
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:179
 msgid "For reference, your current web root path is: %s"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:189
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:158
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:189
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:158
 msgid "Test Mode"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:190
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:190
 msgid "Enable to test Apple Pay functionality throughout your sites without processing real payments."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:229
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:229
 msgid "Your site must be served over HTTPS with a valid SSL certificate."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:239
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php:239
 msgid "Your %1$sMerchant Identity Certificate%2$s cannot be found. Please check your path configuration."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php:176
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php:176
 msgctxt "Apple Pay"
 msgid "Buy with"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:152
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:152
 msgid "Apple Pay payment authorized."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:186
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:186
 msgid "Apple Pay payment failed. %s"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:539
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:255
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:380
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:539
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:255
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:380
 msgid "Subtotal"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:549
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:390
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:549
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:390
 msgid "Discount"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:559
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:400
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:559
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:400
 msgid "Shipping"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:569
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:410
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:569
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:410
 msgid "Fees"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:579
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:420
+#: payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php:579
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:420
 msgid "Taxes"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Frontend.php:259
+#: payment-gateway/External_Checkout/Frontend.php:259
 msgid "or"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Frontend.php:293
+#: payment-gateway/External_Checkout/Frontend.php:293
 msgid "By submitting your payment, you agree to our %1$sterms and conditions%2$s."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:71
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:87
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:66
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:71
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:87
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:66
 msgid "Google Pay"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:94
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:94
 msgctxt "For the merchant to accept Google Pay payments"
 msgid "Accept Google Pay"
 msgstr ""
 
 #. translators: Allow Google Pay button on selected display locations (e.g. cart, checkout, product page...)
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:102
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:102
 msgctxt "Setting title for a multi-select list dropdown of display locations"
 msgid "Allow Google Pay on"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php:159
+#: payment-gateway/External_Checkout/Google_Pay/Admin.php:159
 msgid "Enable to test Google Pay functionality throughout your sites without processing real payments."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:463
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:463
 msgid "Google Pay payment authorized."
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:538
+#: payment-gateway/External_Checkout/Google_Pay/Google_Pay.php:538
 msgid "Google Pay payment failed. %s"
 msgstr ""
 
-#: woocommerce/payment-gateway/External_Checkout/Orders.php:140
-#: woocommerce/payment-gateway/External_Checkout/Orders.php:153
-#: woocommerce/payment-gateway/External_Checkout/Orders.php:157
+#: payment-gateway/External_Checkout/Orders.php:140
+#: payment-gateway/External_Checkout/Orders.php:153
+#: payment-gateway/External_Checkout/Orders.php:157
 msgid "Error %d: Unable to create order. Please try again."
 msgstr ""
 
-#: woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php:179
+#: payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php:179
 msgid "There was a problem processing your order and it is being placed on hold for review. Please contact us to complete the transaction."
 msgstr ""
 
 #. translators: Example: "Authorize.Net Transaction Held for Review". Placeholder: %s - Payment gateway title
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:365
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:365
 msgid "%s Transaction Held for Review"
 msgstr ""
 
 #. translators: Placeholders: %s - payment gateway title
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:436
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:436
 msgid "%s Payment Failed"
 msgstr ""
 
 #. translators: Placeholders: %s - payment gateway title
-#: woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php:463
+#: payment-gateway/Handlers/Abstract_Payment_Handler.php:463
 msgid "%s Transaction Cancelled"
 msgstr ""
 
-#: woocommerce/payment-gateway/Handlers/Capture.php:158
+#: payment-gateway/Handlers/Capture.php:158
 msgid "Order cannot be captured"
 msgstr ""
 
-#: woocommerce/payment-gateway/Handlers/Capture.php:163
+#: payment-gateway/Handlers/Capture.php:163
 msgid "Transaction authorization has expired"
 msgstr ""
 
-#: woocommerce/payment-gateway/Handlers/Capture.php:168
+#: payment-gateway/Handlers/Capture.php:168
 msgid "Transaction has already been fully captured"
 msgstr ""
 
-#: woocommerce/payment-gateway/Handlers/Capture.php:173
+#: payment-gateway/Handlers/Capture.php:173
 msgid "Transaction cannot be captured"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title (such as Authorize.net, Braintree, etc), %2$s - transaction amount. Definitions: Capture, as in capture funds from a credit card.
-#: woocommerce/payment-gateway/Handlers/Capture.php:189
+#: payment-gateway/Handlers/Capture.php:189
 msgid "%1$s Capture of %2$s Approved"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title (such as Authorize.net, Braintree, etc), %2$s - failure message. Definitions: "capture" as in capturing funds from a credit card.
-#: woocommerce/payment-gateway/Handlers/Capture.php:230
+#: payment-gateway/Handlers/Capture.php:230
 msgid "%1$s Capture Failed: %2$s"
 msgstr ""
 
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:261
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:261
 msgid "Pre-Order Tokenization attempt failed (%s)"
 msgstr ""
 
 #. translators: Context: A payment is released for a pre-order. Placeholders: %1$s - Site name, %2$s - Order number
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:309
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:309
 msgid "%1$s - Pre-Order Release Payment for Order %2$s"
 msgstr ""
 
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:316
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:316
 msgid "Payment token missing/invalid."
 msgstr ""
 
 #. translators: Context: A payment is released for a pre-order. Placeholders: %1$s - Payment gateway name, %2$s - Either 'Authorization' or 'Charge' (untranslated), %3$s - Payment method type (e.g. 'PayPal', 'Credit Card', etc.), %4$s - Last four digits of the card or account, %5$s - Expiration date of the payment method
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:342
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:342
 msgid "%1$s %2$s Pre-Order Release Payment Approved: %3$s ending in %4$s (expires %5$s)"
 msgstr ""
 
 #. translators: Context: A payment is released for a pre-order. Placeholders: %1$s - Payment gateway name, %2$s - Payment method type (e.g. 'Bank Account'), %3$s - Last four digits of the account
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:355
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:355
 msgid "%1$s eCheck Pre-Order Release Payment Approved: %2$s ending in %3$s"
 msgstr ""
 
 #. translators: Context: Release of payment for pre-order failed. Placeholder: %s - Error message
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:407
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php:407
 msgid "Pre-Order Release Payment Failed: %s"
 msgstr ""
 
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:358
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:362
 msgid "Subscription Renewal: payment token is missing/invalid."
 msgstr ""
 
 #. translators: Placeholders: %1$s - Site name, %2$s - Order number
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:386
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:390
 msgid "%1$s - Subscription Renewal Order %2$s"
 msgstr ""
 
 #. translators: Placeholders: %1$s - payment gateway title, %2$s - error message; e.g. Order Note: [Payment method] Payment Change failed [error]
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:521
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:525
 msgid "%1$s Payment Change Failed (%2$s)"
 msgstr ""
 
 #. translators: Context: Payment made for order. Placeholders: %1$s - Payment method name (e.g. "Credit Card", "PayPal", etc.), %2$s - Last four digits of the card/account used
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:679
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:683
 msgid "Via %1$s ending in %2$s"
 msgstr ""
 
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:710
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:714
 msgid "Subscriptions"
 msgstr ""
 
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:765
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:769
 msgctxt "hash before order number"
 msgid "#%s"
 msgstr ""
 
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:771
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:775
 msgid "N/A"
 msgstr ""
 
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:870
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:874
 msgid "Payment Token"
 msgstr ""
 
 #. translators: Context: Error message. Placeholder: %s - Label of the related value
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:900
-#: woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:906
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:904
+#: payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:910
 msgid "%s is required."
 msgstr ""
 
-#: woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:186
+#: payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php:186
 msgid "Unknown Error"
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:119
+#: rest-api/Controllers/Settings.php:119
 msgid "Sorry, you cannot list resources."
 msgstr ""
 
 #. translators: Placeholder: %s - setting ID
-#: woocommerce/rest-api/Controllers/Settings.php:168
+#: rest-api/Controllers/Settings.php:168
 msgid "Setting %s does not exist"
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:191
+#: rest-api/Controllers/Settings.php:191
 msgid "Sorry, you cannot edit this resource."
 msgstr ""
 
 #. translators: Placeholder: %s - Error message
-#: woocommerce/rest-api/Controllers/Settings.php:224
+#: rest-api/Controllers/Settings.php:224
 msgid "Could not update setting: %s"
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:294
+#: rest-api/Controllers/Settings.php:294
 msgid "Unique identifier of the setting."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:300
+#: rest-api/Controllers/Settings.php:300
 msgid "The type of the setting."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:307
+#: rest-api/Controllers/Settings.php:307
 msgid "The name of the setting."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:313
+#: rest-api/Controllers/Settings.php:313
 msgid "The description of the setting. It may or may not be used for display."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:319
+#: rest-api/Controllers/Settings.php:319
 msgid "Whether the setting stores an array of values or a single value."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:325
+#: rest-api/Controllers/Settings.php:325
 msgid "A list of valid options, used for validation before storing the value."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:331
+#: rest-api/Controllers/Settings.php:331
 msgid "Optional default value for the setting."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:337
+#: rest-api/Controllers/Settings.php:337
 msgid "The value of the setting."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:346
+#: rest-api/Controllers/Settings.php:346
 msgid "The type of the control."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:353
+#: rest-api/Controllers/Settings.php:353
 msgid "The name of the control. Inherits the setting's name."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:359
+#: rest-api/Controllers/Settings.php:359
 msgid "The description of the control. Inherits the setting's description."
 msgstr ""
 
-#: woocommerce/rest-api/Controllers/Settings.php:365
+#: rest-api/Controllers/Settings.php:365
 msgid "A list of key/value pairs defining the display value of each setting option. The keys should match the options defined in the base setting for validation."
 msgstr ""
 
-#: woocommerce/utilities/class-sv-wp-background-job-handler.php:659
+#: utilities/class-sv-wp-background-job-handler.php:659
 msgid "Job data key \"%s\" not set"
 msgstr ""
 
-#: woocommerce/utilities/class-sv-wp-background-job-handler.php:663
+#: utilities/class-sv-wp-background-job-handler.php:663
 msgid "Job data key \"%s\" is not an array"
 msgstr ""
 
-#: woocommerce/utilities/class-sv-wp-background-job-handler.php:1063
+#: utilities/class-sv-wp-background-job-handler.php:1063
 msgid "Background Processing Test"
 msgstr ""
 
-#: woocommerce/utilities/class-sv-wp-background-job-handler.php:1064
+#: utilities/class-sv-wp-background-job-handler.php:1064
 msgid "Run Test"
 msgstr ""
 
-#: woocommerce/utilities/class-sv-wp-background-job-handler.php:1065
+#: utilities/class-sv-wp-background-job-handler.php:1065
 msgid "This tool will test whether your server is capable of processing background jobs."
 msgstr ""
 
-#: woocommerce/utilities/class-sv-wp-background-job-handler.php:1083
+#: utilities/class-sv-wp-background-job-handler.php:1083
 msgid "Success! You should be able to process background jobs."
 msgstr ""
 
-#: woocommerce/utilities/class-sv-wp-background-job-handler.php:1086
+#: utilities/class-sv-wp-background-job-handler.php:1086
 msgid "Could not connect. Please ask your hosting company to ensure your server has loopback connections enabled."
 msgstr ""

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -429,23 +429,25 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 
 	/**
-	 * Don't copy order-specific meta to renewal orders from the WC_Subscription
-	 * object. Generally the subscription object should not have any order-specific
-	 * meta (aside from `payment_token` and `customer_id`) as they are not
-	 * copied during the upgrade (see do_not_copy_order_meta_during_upgrade()), so
-	 * this method is more of a fallback in case meta accidentally is copied.
+	 * Don't copy order-specific meta to renewal orders from the {@see WC_Subscription} object.
+	 *
+	 * Generally the subscription object should not have any order-specific meta (aside from `payment_token` and `customer_id`)
+	 * as they are not copied during the upgrade (see do_not_copy_order_meta_during_upgrade()),
+	 * so this method is more of a fallback in case meta accidentally is copied.
 	 *
 	 * @since 4.1.0
-	 * @param array $order_meta order meta to copy
-	 * @return array
+	 *
+	 * @param array<mixed>|scalar $order_meta order meta to copy
+	 * @return array<mixed>|scalar
 	 */
 	public function do_not_copy_order_meta( $order_meta ) {
 
 		$meta_keys = $this->get_order_specific_meta_keys();
 
-		foreach ( $order_meta as $index => $meta ) {
+		foreach ( (array) $order_meta as $index => $meta ) {
 
-			if ( in_array( $meta['meta_key'], $meta_keys ) ) {
+			// this accounts for different versions of the Subscriptions filter running before and after WooCommerce Subscriptions 2.5
+			if ( in_array( $index, $meta_keys ) || ( isset( $meta['meta_key'] ) && in_array( $meta['meta_key'], $meta_keys ) ) || ( isset( $meta['_meta_key'] ) && in_array( $meta['_meta_key'], $meta_keys ) ) ) {
 				unset( $order_meta[ $index ] );
 			}
 		}

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -447,7 +447,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		foreach ( (array) $order_meta as $index => $meta ) {
 
 			// this accounts for different versions of the Subscriptions filter running before and after WooCommerce Subscriptions 2.5
-			if ( in_array( $index, $meta_keys ) || ( isset( $meta['meta_key'] ) && in_array( $meta['meta_key'], $meta_keys ) ) || ( isset( $meta['_meta_key'] ) && in_array( $meta['_meta_key'], $meta_keys ) ) ) {
+			if ( in_array( $index, $meta_keys ) || ( isset( $meta['meta_key'] ) && in_array( $meta['meta_key'], $meta_keys ) ) ) {
 				unset( $order_meta[ $index ] );
 			}
 		}

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -98,7 +98,11 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		add_filter( 'woocommerce_my_subscriptions_payment_method', array( $this, 'maybe_render_payment_method' ), 10, 3 );
 
 		// don't copy over order-specific meta to the WC_Subscription object during renewal processing
-		add_filter( 'wcs_renewal_order_meta', array( $this, 'do_not_copy_order_meta' ) );
+		if ( SV_WC_Plugin_Compatibility::is_wc_subscriptions_version_gte( '2.5' ) ) {
+			add_filter( 'wc_subscriptions_renewal_order_data', [ $this, 'do_not_copy_order_meta' ] );
+		} else {
+			add_filter( 'wcs_renewal_order_meta', [ $this, 'do_not_copy_order_meta' ] );
+		}
 
 		// process the Change Payment "transaction"
 		add_filter( 'wc_payment_gateway_' . $this->get_gateway()->get_id() . '_process_payment', array( $this, 'process_change_payment' ), 10, 3 );


### PR DESCRIPTION
## Closes #640 

The filters should be compatible. We can probably roll this out contextually to #641  which this PR bases itseful upon.

I have found filter declared in Subscriptions WC_Subscriptions_Data_Copier:125-144 (see class-wc-subscriptions-data-copier.php) -- declared as follows

```php
	    /**
		 * Filters the data to be copied from one object to another.
		 *
		 * This filter name contains a dynamic part, $this->copy_type. The full set of hooks include:
		 *     - wc_subscriptions_subscription_data
		 *     - wc_subscriptions_parent_data
		 *     - wc_subscriptions_renewal_order_data
		 *     - wc_subscriptions_resubscribe_order_data
		 *
		 * @since subscriptions-core 2.5.0
		 *
		 * @param array    $data {
		 *     The data to be copied to the "to" object. Each value is keyed by the meta key. Example format [ '_meta_key' => 'meta_value' ].
		 *
		 *     @type mixed $meta_value The meta value to be copied.
		 * }
		 * @param WC_Order $from_object The object to copy data from.
		 * @param WC_Order $to_object   The object to copy data to.
		 */
		$data = apply_filters( "wc_subscriptions_{$this->copy_type}_data", $data, $this->to_object, $this->from_object );
```
