### PR TITLE
Allow plugins to hook into the transaction response

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -406,6 +406,9 @@ abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 			// Handle the order based on the response
 			$this->process_transaction_response( $order, $response );
 
+			// Allow plugins to hook into the transaction response
+			do_action( 'wc_payment_gateway_transaction_response', $order, $response );
+
 		} catch ( SV_WC_Payment_Gateway_Exception $e ) {
 
 			if ( $order && $order->needs_payment() ) {


### PR DESCRIPTION
We have an action that need the transaction response and send to an API software that process the transaction. Actually is hardcoded and it's not the best way to do it. Better to make as WordPress way, with do_action hook. This line is good for other developers that wants to hook in that line of code.