### PR TITLE
Add methods to work with the payment processing context

### DIFF
--- a/woocommerce/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php
+++ b/woocommerce/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php
@@ -531,7 +531,7 @@ abstract class Gateway_Checkout_Block_Integration extends AbstractPaymentMethodT
 	 *
 	 * @see PaymentContext::$payment_data is converted to `$_POST` by WC core when handling legacy payments.
 	 * @see \Automattic\WooCommerce\StoreApi\Legacy::process_legacy_payment()
-	 * @see SV_WC_Payment_Gateway::is_block_checkout()
+	 * @see SV_WC_Payment_Gateway::get_processing_context()
 	 *
 	 * @internal
 	 *
@@ -548,7 +548,7 @@ abstract class Gateway_Checkout_Block_Integration extends AbstractPaymentMethodT
 		 * between blocks checkout and legacy shortcode checkout - this will be accessed in $_POST data along with the other field data.
 		 * @see SV_WC_Payment_Gateway_Payment_Form::get_payment_fields()
 		 */
-		$additional_payment_data[ 'wc-' . $this->gateway->get_id_dasherized() . '-context' ] = 'block';
+		$additional_payment_data[ 'wc-' . $this->gateway->get_id_dasherized() . '-context' ] = $this->gateway::PROCESSING_CONTEXT_BLOCK;
 
 		/**
 		 * Fetch the provider-based token ID for the core token ID:

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -296,7 +296,9 @@ class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 	 */
 	protected function get_payment_fields() : array {
 
-		switch ( $this->get_gateway()->get_payment_type() ) {
+		$gateway = $this->get_gateway();
+
+		switch ( $gateway->get_payment_type() ) {
 
 			case 'credit-card':
 				$fields = $this->get_credit_card_fields();
@@ -319,9 +321,9 @@ class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 		$fields = wp_parse_args( $fields, [
 			'context' => [
 				'type'  => 'hidden',
-				'id'    => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-context',
-				'name'  => 'wc-' . $this->get_gateway()->get_id_dasherized() . '-context',
-				'value' => 'shortcode',
+				'id'    => 'wc-' . $gateway->get_id_dasherized() . '-context',
+				'name'  => 'wc-' . $gateway->get_id_dasherized() . '-context',
+				'value' => $gateway::PROCESSING_CONTEXT_SHORTCODE,
 			],
 		] );
 
@@ -339,7 +341,7 @@ class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 		 * @param array<string, mixed> $fields in the format supported by {@see woocommerce_form_field()}
 		 * @param SV_WC_Payment_Gateway_Payment_Form $payment_form payment form instance
 		 */
-		return (array) apply_filters( 'wc_' . $this->get_gateway()->get_id() . '_payment_form_default_payment_form_fields', $fields, $this );
+		return (array) apply_filters( 'wc_' . $gateway->get_id() . '_payment_form_default_payment_form_fields', $fields, $this );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -4392,7 +4392,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 */
 	protected function is_processing_block_checkout(): bool {
 
-		return $this->is_processing_context( self::PROCESSING_CONTEXT_BLOCK ) && Blocks_Handler::is_checkout_block_in_use();
+		return $this->is_processing_context( self::PROCESSING_CONTEXT_BLOCK );
 	}
 
 
@@ -4411,11 +4411,12 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Checks if we're currently in teh given payment processing context.
+	 * Checks if we're currently in the given payment processing context.
 	 *
 	 * @since 5.12.1-dev.1
 	 * @see Gateway_Checkout_Block_Integration::prepare_payment_data()
 	 *
+	 * @param string $context
 	 * @return bool
 	 */
 	protected function is_processing_context( string $context ): bool {

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -141,6 +141,10 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	/** Pre-orders integration ID */
 	const INTEGRATION_PRE_ORDERS = 'pre_orders';
 
+	public const PROCESSING_CONTEXT_SHORTCODE = 'shortcode';
+
+	public const PROCESSING_CONTEXT_BLOCK = 'block';
+
 	/** @var SV_WC_Payment_Gateway_Plugin the parent plugin class */
 	private $plugin;
 
@@ -4382,14 +4386,41 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	/**
 	 * Returns true if currently processing payment from block-based checkout.
 	 *
-	 * @since 5.12.0
+	 * @since 5.12.1-dev.1
+	 *
+	 * @return bool
+	 */
+	protected function is_processing_block_checkout(): bool {
+
+		return $this->is_processing_context( self::PROCESSING_CONTEXT_BLOCK ) && Blocks_Handler::is_checkout_block_in_use();
+	}
+
+
+	/**
+	 * Gets the current payment processing context.
+	 *
+	 * @since 5.12.1-dev.1
+	 * @see Gateway_Checkout_Block_Integration::prepare_payment_data()
+	 *
+	 * @return string
+	 */
+	protected function get_processing_context(  ): ?string {
+
+		return $_POST[ 'wc-' . $this->get_id_dasherized() . '-context' ] ?: null;
+	}
+
+
+	/**
+	 * Checks if we're currently in teh given payment processing context.
+	 *
+	 * @since 5.12.1-dev.1
 	 * @see Gateway_Checkout_Block_Integration::prepare_payment_data()
 	 *
 	 * @return bool
 	 */
-	protected function is_block_checkout(): bool {
+	protected function is_processing_context( string $context ): bool {
 
-		return ! empty( $_POST[ 'sv_wc_is_block_checkout' ] ) && Blocks_Handler::is_checkout_block_in_use();
+		return $this->get_processing_context() === $context;
 	}
 
 


### PR DESCRIPTION
# Summary

In the 5.12.0 release, we added "context" to the payment data, both in shortcode and block checkout.
However, we did not add any methods that plugins could use to determine the context easily.

This PR adds a few helper methods to the gateway class to determine the current processing context.

## Details

We did have a `SV_WC_Payment_Gateway::is_block_checkout()` method, which used a POST value that we were using while developing 5.12.0. However, at some point we changed the POST data, and forgot to update to work with the new context field.

I renamed the existing `SV_WC_Payment_Gateway::is_block_checkout()` method, because it's only used in one plugin, which hasn't been released yet.

I used the term "processing context" because "payment context" could easily be confused with the `PaymentContext` passed to `Gateway_Checkout_Block_Integration::prepare_payment_data()`. Also, "checkout context" did not seem precise enough, because "checkout" can either refer to the checkout page or the action of checking out.