### PR TITLE
Add support for dynamic properties to improve compatibility with newer PHP versions

### DIFF
--- a/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce-framework-plugin-loader-sample.php
@@ -47,6 +47,7 @@ if ( ! is_woocommerce_active() ) {
  *
  * @since 1.0.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Framework_Plugin_Loader {
 
 

--- a/woocommerce/Addresses/Address.php
+++ b/woocommerce/Addresses/Address.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Address
  *
  * @since 5.3.0
  */
+#[\AllowDynamicProperties]
 class Address {
 
 

--- a/woocommerce/Addresses/Customer_Address.php
+++ b/woocommerce/Addresses/Customer_Address.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Address
  *
  * @since 5.3.0
  */
+#[\AllowDynamicProperties]
 class Customer_Address extends Address {
 
 

--- a/woocommerce/Blocks/Block_Integration.php
+++ b/woocommerce/Blocks/Block_Integration.php
@@ -41,6 +41,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Blocks\
  *
  * @since 5.12.0
  */
+#[\AllowDynamicProperties]
 abstract class Block_Integration implements IntegrationInterface {
 
 

--- a/woocommerce/Blocks/Blocks_Handler.php
+++ b/woocommerce/Blocks/Blocks_Handler.php
@@ -20,6 +20,7 @@ if ( ! class_exists( '\SkyVerge\WooCommerce\PluginFramework\v5_12_0\Blocks\Block
  *
  * @since 5.11.11
  */
+#[\AllowDynamicProperties]
 class Blocks_Handler {
 
 

--- a/woocommerce/Country_Helper.php
+++ b/woocommerce/Country_Helper.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Country
  *
  * @since 5.4.3
  */
+#[\AllowDynamicProperties]
 class Country_Helper {
 
 

--- a/woocommerce/Handlers/Script_Handler.php
+++ b/woocommerce/Handlers/Script_Handler.php
@@ -39,6 +39,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Handler
  *
  * @since 5.7.0
  */
+#[\AllowDynamicProperties]
 abstract class Script_Handler {
 
 

--- a/woocommerce/Lifecycle.php
+++ b/woocommerce/Lifecycle.php
@@ -42,6 +42,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Plugin\
  *
  * @since 5.1.0
  */
+#[\AllowDynamicProperties]
 class Lifecycle {
 
 

--- a/woocommerce/Settings_API/Abstract_Settings.php
+++ b/woocommerce/Settings_API/Abstract_Settings.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Setting
  *
  * @since 5.7.0
  */
+#[\AllowDynamicProperties]
 abstract class Abstract_Settings {
 
 

--- a/woocommerce/Settings_API/Control.php
+++ b/woocommerce/Settings_API/Control.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Setting
  *
  * @since 5.7.0
  */
+#[\AllowDynamicProperties]
 class Control {
 
 

--- a/woocommerce/Settings_API/Setting.php
+++ b/woocommerce/Settings_API/Setting.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Setting
  *
  * @since 5.7.0
  */
+#[\AllowDynamicProperties]
 class Setting {
 
 

--- a/woocommerce/admin/Notes_Helper.php
+++ b/woocommerce/admin/Notes_Helper.php
@@ -35,6 +35,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Admin\\
  *
  * @since 5.6.0
  */
+#[\AllowDynamicProperties]
 class Notes_Helper {
 
 

--- a/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
+++ b/woocommerce/admin/abstract-sv-wc-plugin-admin-setup-wizard.php
@@ -40,6 +40,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Admin\\
  *
  * @since 5.2.2
  */
+#[\AllowDynamicProperties]
 abstract class Setup_Wizard {
 
 

--- a/woocommerce/api/Abstract_Cacheable_API_Base.php
+++ b/woocommerce/api/Abstract_Cacheable_API_Base.php
@@ -40,8 +40,8 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\API\\Ab
  *
  * @since 5.10.10
  */
-abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
-{
+#[\AllowDynamicProperties]
+abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base {
 
 
 	/** @var bool whether the response was loaded from cache */
@@ -266,6 +266,7 @@ abstract class Abstract_Cacheable_API_Base extends SV_WC_API_Base
 
 		return $response_data;
 	}
+
 
 }
 

--- a/woocommerce/api/abstract-sv-wc-api-json-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-request.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_A
  *
  * @since 4.3.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_API_JSON_Request implements SV_WC_API_Request {
 
 

--- a/woocommerce/api/abstract-sv-wc-api-json-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-json-response.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_A
  *
  * @since 4.3.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_API_JSON_Response implements SV_WC_API_Response {
 
 

--- a/woocommerce/api/abstract-sv-wc-api-xml-request.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-request.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_A
  *
  * @since 4.3.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_API_XML_Request implements SV_WC_API_Request {
 
 

--- a/woocommerce/api/abstract-sv-wc-api-xml-response.php
+++ b/woocommerce/api/abstract-sv-wc-api-xml-response.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_A
  *
  * @since 4.3.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_API_XML_Response implements SV_WC_API_Response {
 
 

--- a/woocommerce/api/class-sv-wc-api-base.php
+++ b/woocommerce/api/class-sv-wc-api-base.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_A
  *
  * @version 2.2.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_API_Base {
 
 

--- a/woocommerce/api/class-sv-wc-api-exception.php
+++ b/woocommerce/api/class-sv-wc-api-exception.php
@@ -32,6 +32,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_A
 /**
  * Plugin Framework API Exception - generic API Exception
  */
+#[\AllowDynamicProperties]
 class SV_WC_API_Exception extends SV_WC_Plugin_Exception { }
 
 

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -3,6 +3,7 @@
 2024.nn.nn - version 5.12.1
  * Tweak - Handle support in gateways for external checkouts while corresponding express payment methods are in use in the cart and checkout blocks
  * Fix - Check if the session is set before trying to add a WooCommerce notice
+ * Misc - Improve compatibility with PHP 8.2+ by allowing dynamic properties in the framework
 
 2023.12.14 - version 5.12.0
  * Feature - Add support for WooCommerce Cart and Checkout blocks

--- a/woocommerce/class-sv-wc-admin-notice-handler.php
+++ b/woocommerce/class-sv-wc-admin-notice-handler.php
@@ -38,6 +38,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_A
  *
  * @since 3.0.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Admin_Notice_Handler {
 
 

--- a/woocommerce/class-sv-wc-framework-bootstrap.php
+++ b/woocommerce/class-sv-wc-framework-bootstrap.php
@@ -35,7 +35,8 @@ if ( ! class_exists( 'SV_WC_Framework_Bootstrap' ) ) :
  * compatible framework plugins.
  *
  * @since 2.0.0
- */
+*/
+#[\AllowDynamicProperties]
 class SV_WC_Framework_Bootstrap {
 
 

--- a/woocommerce/class-sv-wc-framework-bootstrap.php
+++ b/woocommerce/class-sv-wc-framework-bootstrap.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'SV_WC_Framework_Bootstrap' ) ) :
  * compatible framework plugins.
  *
  * @since 2.0.0
-*/
+ */
 #[\AllowDynamicProperties]
 class SV_WC_Framework_Bootstrap {
 

--- a/woocommerce/class-sv-wc-helper.php
+++ b/woocommerce/class-sv-wc-helper.php
@@ -39,6 +39,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_H
  *
  * @since 2.2.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Helper {
 
 

--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_H
  *
  * @since 4.3.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Hook_Deprecator {
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -50,6 +50,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 2.0.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Plugin_Compatibility {
 
 

--- a/woocommerce/class-sv-wc-plugin-dependencies.php
+++ b/woocommerce/class-sv-wc-plugin-dependencies.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 5.2.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Plugin_Dependencies {
 
 

--- a/woocommerce/class-sv-wc-plugin-exception.php
+++ b/woocommerce/class-sv-wc-plugin-exception.php
@@ -32,6 +32,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
 /**
  * Plugin Framework Exception - generic Exception
  */
+#[\AllowDynamicProperties]
 class SV_WC_Plugin_Exception extends \Exception { }
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -42,6 +42,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @version 5.8.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_Plugin {
 
 

--- a/woocommerce/class-sv-wp-admin-message-handler.php
+++ b/woocommerce/class-sv-wp-admin-message-handler.php
@@ -52,6 +52,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WP_A
  *
  * @version 1.0.1
  */
+#[\AllowDynamicProperties]
 class SV_WP_Admin_Message_Handler {
 
 

--- a/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
+++ b/woocommerce/compatibility/abstract-sv-wc-data-compatibility.php
@@ -35,6 +35,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_D
  * @since 4.6.0
  * @deprecated 5.5.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_Data_Compatibility {
 
 }

--- a/woocommerce/compatibility/class-sv-wc-order-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-order-compatibility.php
@@ -40,6 +40,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_O
  *
  * @since 4.6.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Order_Compatibility extends SV_WC_Data_Compatibility {
 
 

--- a/woocommerce/compatibility/class-sv-wc-subscription-compatibility.php
+++ b/woocommerce/compatibility/class-sv-wc-subscription-compatibility.php
@@ -33,6 +33,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_S
  *
  * @since 5.11.1
  */
+#[\AllowDynamicProperties]
 class SV_WC_Subscription_Compatibility extends SV_WC_Data_Compatibility {
 
 	/**

--- a/woocommerce/payment-gateway/Blocks/Gateway_Blocks_Handler.php
+++ b/woocommerce/payment-gateway/Blocks/Gateway_Blocks_Handler.php
@@ -23,6 +23,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  * @property Gateway_Checkout_Block_Integration $checkout_Block_Integration
  * @property SV_WC_Payment_Gateway_Plugin $plugin
  */
+#[\AllowDynamicProperties]
 class Gateway_Blocks_Handler extends Blocks_Handler {
 
 

--- a/woocommerce/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php
+++ b/woocommerce/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php
@@ -45,6 +45,7 @@ if ( ! class_exists( '\SkyVerge\WooCommerce\PluginFramework\v5_12_0\Payment_Gate
  *
  * @since 5.12.0
  */
+#[\AllowDynamicProperties]
 abstract class Gateway_Checkout_Block_Integration extends AbstractPaymentMethodType {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Admin.php
@@ -35,6 +35,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Admin' ) ) :
  *
  * @since 5.10.0
  */
+#[\AllowDynamicProperties]
 abstract class Admin {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
+++ b/woocommerce/payment-gateway/External_Checkout/External_Checkout.php
@@ -36,6 +36,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\External_Checkout' ) ) :
  *
  * @since 5.10.0
  */
+#[\AllowDynamicProperties]
 abstract class External_Checkout {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Frontend.php
+++ b/woocommerce/payment-gateway/External_Checkout/Frontend.php
@@ -41,6 +41,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.10.0
  */
+#[\AllowDynamicProperties]
 abstract class Frontend extends Script_Handler {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Google_Pay/AJAX.php
+++ b/woocommerce/payment-gateway/External_Checkout/Google_Pay/AJAX.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.10.0
  */
+#[\AllowDynamicProperties]
 class AJAX {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/Google_Pay/Admin.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.10.0
  */
+#[\AllowDynamicProperties]
 class Admin extends \SkyVerge\WooCommerce\PluginFramework\v5_12_0\Payment_Gateway\External_Checkout\Admin {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Google_Pay/Frontend.php
+++ b/woocommerce/payment-gateway/External_Checkout/Google_Pay/Frontend.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.10.0
  */
+#[\AllowDynamicProperties]
 class Frontend extends \SkyVerge\WooCommerce\PluginFramework\v5_12_0\Payment_Gateway\External_Checkout\Frontend {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php
+++ b/woocommerce/payment-gateway/External_Checkout/Google_Pay/Google_Pay.php
@@ -40,6 +40,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.10.0
  */
+#[\AllowDynamicProperties]
 class Google_Pay extends External_Checkout {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/Orders.php
+++ b/woocommerce/payment-gateway/External_Checkout/Orders.php
@@ -37,6 +37,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\Orders' ) ) :
  *
  * @since 5.10.0
  */
+#[\AllowDynamicProperties]
 class Orders {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-request.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.7.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Apple_Pay_API_Request extends SV_WC_API_JSON_Request {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api-response.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.7.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Apple_Pay_API_Response extends SV_WC_API_JSON_Response {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-api.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.7.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Apple_Pay_API extends SV_WC_API_Base {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/api/class-sv-wc-payment-gateway-apple-pay-payment-response.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.7.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Apple_Pay_Payment_Response extends SV_WC_API_JSON_Response {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-admin.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.7.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Apple_Pay_Admin extends Admin {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-ajax.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.7.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Apple_Pay_AJAX {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay-frontend.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.7.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Apple_Pay_Frontend extends \SkyVerge\WooCommerce\PluginFramework\v5_12_0\Payment_Gateway\External_Checkout\Frontend {
 
 

--- a/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
+++ b/woocommerce/payment-gateway/External_Checkout/apple-pay/class-sv-wc-payment-gateway-apple-pay.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.7.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Apple_Pay extends Payment_Gateway\External_Checkout\External_Checkout {
 
 

--- a/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.4.0
  */
+#[\AllowDynamicProperties]
 abstract class Abstract_Hosted_Payment_Handler extends Abstract_Payment_Handler {
 
 

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -40,6 +40,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.4.0
  */
+#[\AllowDynamicProperties]
 abstract class Abstract_Payment_Handler {
 
 

--- a/woocommerce/payment-gateway/Handlers/Capture.php
+++ b/woocommerce/payment-gateway/Handlers/Capture.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.3.0
  */
+#[\AllowDynamicProperties]
 class Capture {
 
 

--- a/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
+++ b/woocommerce/payment-gateway/admin/abstract-sv-wc-payment-gateway-plugin-admin-setup-wizard.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.2.2
  */
+#[\AllowDynamicProperties]
 abstract class Setup_Wizard extends Framework\Admin\Setup_Wizard {
 
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-order.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 5.0.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Admin_Order {
 
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-payment-token-editor.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.3.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Admin_Payment_Token_Editor {
 
 

--- a/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
+++ b/woocommerce/payment-gateway/admin/class-sv-wc-payment-gateway-admin-user-handler.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.3.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Admin_User_Handler {
 
 

--- a/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
+++ b/woocommerce/payment-gateway/api/class-sv-wc-payment-gateway-api-response-message-helper.php
@@ -52,6 +52,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 2.2.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_API_Response_Message_Helper {
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -36,6 +36,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 1.0.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-helper.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 3.0.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Helper {
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-hosted.php
@@ -40,6 +40,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 1.0.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_Payment_Gateway_Hosted extends SV_WC_Payment_Gateway {
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.0.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_My_Payment_Methods extends Handlers\Script_Handler {
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-payment-form.php
@@ -39,6 +39,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.0.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Payment_Form extends Handlers\Script_Handler {
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -60,6 +60,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @version 2.0.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 5.1.4
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Privacy extends \WC_Abstract_Privacy {
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -39,6 +39,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 1.0.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 

--- a/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
+++ b/woocommerce/payment-gateway/exceptions/class-sv-wc-payment-gateway-exception.php
@@ -32,6 +32,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
 /**
  * Payment Gateway Exception - generic payment failure Exception
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Exception extends SV_WC_Plugin_Exception { }
 
 

--- a/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
+++ b/woocommerce/payment-gateway/integrations/abstract-sv-wc-payment-gateway-integration.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.1.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WC_Payment_Gateway_Integration {
 
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-pre-orders.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.1.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Integration_Pre_Orders extends SV_WC_Payment_Gateway_Integration {
 
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.1.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gateway_Integration {
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-token.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * Represents a credit card or check payment token
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Payment_Token {
 
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -34,6 +34,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WC_P
  *
  * @since 4.3.0
  */
+#[\AllowDynamicProperties]
 class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 
 

--- a/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
+++ b/woocommerce/payment-gateway/rest-api/class-sv-wc-payment-gateway-plugin-rest-api.php
@@ -38,6 +38,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\Payment
  *
  * @since 5.2.0
  */
+#[\AllowDynamicProperties]
 class REST_API extends Plugin_REST_API {
 
 

--- a/woocommerce/rest-api/Controllers/Settings.php
+++ b/woocommerce/rest-api/Controllers/Settings.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\REST_AP
  *
  * @since 5.7.0
  */
+#[\AllowDynamicProperties]
 class Settings extends \WP_REST_Controller {
 
 

--- a/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
+++ b/woocommerce/rest-api/class-sv-wc-plugin-rest-api.php
@@ -37,6 +37,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\REST_AP
  *
  * @since 5.2.0
  */
+#[\AllowDynamicProperties]
 class REST_API {
 
 

--- a/woocommerce/utilities/class-sv-wp-async-request.php
+++ b/woocommerce/utilities/class-sv-wp-async-request.php
@@ -43,6 +43,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WP_A
  *
  * @since 4.4.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WP_Async_Request {
 
 

--- a/woocommerce/utilities/class-sv-wp-background-job-handler.php
+++ b/woocommerce/utilities/class-sv-wp-background-job-handler.php
@@ -54,6 +54,7 @@ if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_0\\SV_WP_B
  *
  * @since 4.4.0
  */
+#[\AllowDynamicProperties]
 abstract class SV_WP_Background_Job_Handler extends SV_WP_Async_Request {
 
 

--- a/woocommerce/utilities/class-sv-wp-job-batch-handler.php
+++ b/woocommerce/utilities/class-sv-wp-job-batch-handler.php
@@ -37,6 +37,7 @@
  *
  * @since 4.8.0
  */
+#[\AllowDynamicProperties]
 class SV_WP_Job_Batch_Handler {
 
 


### PR DESCRIPTION
Adds a `#[\AllowDynamicProperties]` declaration at the beginning of all classes in the framework. This is a bit of a blanket solution to address certain deprecation notices related to PHP 8.2 but that may be triggered in frameworked plugins. Note that core WP adopted a similar strategy. Individual plugins may still need to address compatibility if they use dynamic properties in their own classes.

## QA

- [x] Code review