### PR TITLE
 Add the checkout button text to the payment data payload 

### DIFF
--- a/woocommerce/Blocks/Traits/Block_Integration_Trait.php
+++ b/woocommerce/Blocks/Traits/Block_Integration_Trait.php
@@ -178,9 +178,9 @@ trait Block_Integration_Trait {
 	 * However, it is assumed that gateways supporting a block will use a single script for all the included gateways.
 	 * If this is not the case, then any outlier gateway should override this method or filter out the URL.
 	 *
-	 * @return string
-	 *@since 5.12.0
+	 * @since 5.12.0
 	 *
+	 * @return string
 	 */
 	protected function get_main_script_url() : string {
 
@@ -209,9 +209,9 @@ trait Block_Integration_Trait {
 	 * However, it is assumed that gateways supporting a block will use a single stylesheet for all the included gateways.
 	 * If this is not the case, then any outlier gateway should override this method or filter out the URL.
 	 *
-	 * @return string
-	 *@since 5.12.0
+	 * @since 5.12.0
 	 *
+	 * @return string
 	 */
 	protected function get_main_script_stylesheet_url() : string {
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -519,7 +519,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * @param SV_WC_Payment_Gateway $gateway
 		 */
 		$params = (array) apply_filters( 'sv_wc_payment_gateway_payment_form_localized_script_params',  [
-			'checkout_button_text'            => $this->get_order_button_text(),
+			'order_button_text'               => $this->get_order_button_text(),
 			'card_number_missing'             => esc_html_x( 'Card number is missing', 'Credit or debit card','woocommerce-plugin-framework' ),
 			'card_number_invalid'             => esc_html_x( 'Card number is invalid', 'Credit or debit card', 'woocommerce-plugin-framework' ),
 			'card_number_digits_invalid'      => esc_html_x( 'Card number is invalid (only digits allowed)', 'Credit or debit card', 'woocommerce-plugin-framework' ),

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -794,8 +794,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * Allow actors to modify the "place order" button text.
 		 *
 		 * @since 4.0.0
+		 *
 		 * @param string $text button text
-		 * @param SV_WC_Payment_Gateway $this instance
+		 * @param SV_WC_Payment_Gateway $gateway the current gateway instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_order_button_text', $text, $this );
 	}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -826,6 +826,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	/**
 	 * Gets the WooCommerce Checkout Block integration.
 	 *
+	 * @since 5.11.11
+	 *
 	 * @return Gateway_Checkout_Block_Integration|null
 	 */
 	public function get_checkout_block_integration_instance() : ?Gateway_Checkout_Block_Integration {
@@ -837,6 +839,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 	/**
 	 * Gets the WooCommerce Cart Block integration.
+	 *
+	 * @since 5.11.11
 	 *
 	 * @return IntegrationInterface|null
 	 */

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -519,6 +519,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 * @param SV_WC_Payment_Gateway $gateway
 		 */
 		$params = (array) apply_filters( 'sv_wc_payment_gateway_payment_form_localized_script_params',  [
+			'checkout_button_text'            => $this->get_order_button_text(),
 			'card_number_missing'             => esc_html_x( 'Card number is missing', 'Credit or debit card','woocommerce-plugin-framework' ),
 			'card_number_invalid'             => esc_html_x( 'Card number is invalid', 'Credit or debit card', 'woocommerce-plugin-framework' ),
 			'card_number_digits_invalid'      => esc_html_x( 'Card number is invalid (only digits allowed)', 'Credit or debit card', 'woocommerce-plugin-framework' ),

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -795,7 +795,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		 *
 		 * @since 4.0.0
 		 * @param string $text button text
-		 * @param \SV_WC_Payment_Gateway $this instance
+		 * @param SV_WC_Payment_Gateway $this instance
 		 */
 		return apply_filters( 'wc_payment_gateway_' . $this->get_id() . '_order_button_text', $text, $this );
 	}


### PR DESCRIPTION
## Summary

Adds the checkout button text to the payment data payload that may be used by the FE scripts. This in turn will make sure we hit a filter to let merchants customize that button text.

### Story [MWC-15558](https://godaddy-corp.atlassian.net/browse/MWC-15558)