### PR TITLE
Fix `remove_support()` method in base gateway class

### DIFF
--- a/woocommerce/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php
+++ b/woocommerce/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php
@@ -161,7 +161,7 @@ abstract class Gateway_Checkout_Block_Integration extends AbstractPaymentMethodT
 			'enabled_card_types'   => $this->get_enabled_card_types(), // card types that are enabled in settings
 			'defaults'             => $this->get_gateway_defaults(), // used to pre-populate payment method fields (typically in test mode)
 			'placeholders'         => $this->get_placeholders(), // used in some payment method fields
-			'supports'             => $this->gateway->supports, // list of supported features
+			'supports'             => array_values( $this->gateway->supports ), // list of supported features
 			'flags'                => $this->get_gateway_flags(), // list of gateway configuration flags
 			'gateway'              => $this->get_gateway_configuration(), // other gateway configuration values
 			'apple_pay'            => $this->get_apple_pay_configuration(), // Apple Pay configuration values

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -4083,20 +4083,25 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		foreach ( $feature as $name ) {
 
-			unset( $this->supports[ array_search( $name, $this->supports ) ] );
+			// Bail if the feature already isn't supported
+			if( $key = array_search( $name, $this->supports ) !== false ){
 
-			/**
-			 * Payment Gateway Remove Support Action.
-			 *
-			 * Fired when removing support for a specific gateway feature. Allows other actors
-			 * (including ourselves) to take action when support is removed.
-			 *
-			 * @since 4.1.0
-			 *
-			 * @param SV_WC_Payment_Gateway $this instance
-			 * @param string $name of supported feature being removed
-			 */
-			do_action( 'wc_payment_gateway_' . $this->get_id() . '_removed_support_' . str_replace( '-', '_', $name ), $this, $name );
+				unset( $this->supports[ $key ] );
+				
+
+				/**
+				 * Payment Gateway Remove Support Action.
+				 *
+				 * Fired when removing support for a specific gateway feature. Allows other actors
+				 * (including ourselves) to take action when support is removed.
+				 *
+				 * @since 4.1.0
+				 *
+				 * @param SV_WC_Payment_Gateway $this instance
+				 * @param string $name of supported feature being removed
+				 */
+				do_action( 'wc_payment_gateway_' . $this->get_id() . '_removed_support_' . str_replace( '-', '_', $name ), $this, $name );
+			}
 		}
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -4081,13 +4081,15 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			$feature = array( $feature );
 		}
 
+		$did_remove = false; 
+
 		foreach ( $feature as $name ) {
 
 			// Bail if the feature already isn't supported
 			if( $key = array_search( $name, $this->supports ) !== false ){
 
 				unset( $this->supports[ $key ] );
-				
+				$did_remove = true;
 
 				/**
 				 * Payment Gateway Remove Support Action.
@@ -4102,6 +4104,11 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 				 */
 				do_action( 'wc_payment_gateway_' . $this->get_id() . '_removed_support_' . str_replace( '-', '_', $name ), $this, $name );
 			}
+		}
+
+		if( $did_remove ){
+			// re-index to clean up any new gaps
+			$this->supports = array_values( $this->supports );
 		}
 	}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -4064,38 +4064,38 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 				 */
 				do_action( 'wc_payment_gateway_' . $this->get_id() . '_supports_' . str_replace( '-', '_', $name ), $this, $name );
 			}
-
 		}
+
+		$this->supports = array_values( $this->supports );
 	}
 
 
 	/**
-	 * Remove support for the named feature or features
+	 * Removes support for the named feature or features.
 	 *
 	 * @since 4.1.0
+	 *
 	 * @param string|array $feature feature name or names not supported by this gateway
 	 */
 	public function remove_support( $feature ) {
 
 		if ( ! is_array( $feature ) ) {
-			$feature = array( $feature );
+			$feature = [ $feature ];
 		}
-
-		$did_remove = false; 
 
 		foreach ( $feature as $name ) {
 
-			// Bail if the feature already isn't supported
-			if( $key = array_search( $name, $this->supports ) !== false ){
+			$key = array_search( $name, $this->supports );
+
+			if ( $key !== false ) {
 
 				unset( $this->supports[ $key ] );
-				$did_remove = true;
 
 				/**
 				 * Payment Gateway Remove Support Action.
 				 *
-				 * Fired when removing support for a specific gateway feature. Allows other actors
-				 * (including ourselves) to take action when support is removed.
+				 * Fired when removing support for a specific gateway feature.
+				 * Allows other actors (including ourselves) to take action when support is removed.
 				 *
 				 * @since 4.1.0
 				 *
@@ -4106,21 +4106,21 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			}
 		}
 
-		if( $did_remove ){
-			// re-index to clean up any new gaps
-			$this->supports = array_values( $this->supports );
-		}
+		// re-index the array
+		$this->supports = array_values( $this->supports );
 	}
 
 
 	/**
-	 * Set all features supported
+	 * Set all features supported.
 	 *
 	 * @since 1.0.0
-	 * @param array $features array of supported feature names
+	 *
+	 * @param array|string $features feature or array of supported feature names
 	 */
 	public function set_supports( $features ) {
-		$this->supports = $features;
+
+		$this->supports = array_values( (array) $features );
 	}
 
 


### PR DESCRIPTION
# Summary

Prevents `SV_WC_Payment_Gateway::remove_support()` from erroneously removing the item at index 0 when `$name` is not found (i.e. feature is already not supported) and also from creating gaps in gateway `supports` array.

[Slack discovery](https://godaddy.slack.com/archives/C06748WQS2Z/p1708347025232569?thread_ts=1708092348.195799&cid=C06748WQS2Z) for context (s/o @sporter1-godaddy).

### Issue: [MWC-15631](https://godaddy-corp.atlassian.net/browse/MWC-15631?atlOrigin=eyJpIjoiMzkxMmFkNmYxZWJiNDVhMTk3MGMxOTI4MmFkMWZmZmYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

# QA
- [ ] Attempting to remove an already-unsupported feature does not change the `supports` array
- [ ] Removing supported features works as expected
- [ ] When a feature is removed, the `supports` array is not left with any index gaps