### PR TITLE
Use gateway FW path when loading block handler files

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2024.nn.nn - version 5.12.3
+ * Fix - Ensure gateway block handler files are loaded from payment gateway framework path
 
 2024.03.21 - version 5.12.2
  * Tweak - Add non-gateway cart and checkout blocks supporting logic

--- a/woocommerce/payment-gateway/Blocks/Gateway_Blocks_Handler.php
+++ b/woocommerce/payment-gateway/Blocks/Gateway_Blocks_Handler.php
@@ -59,7 +59,7 @@ class Gateway_Blocks_Handler extends Blocks_Handler {
 			/** @var SV_WC_Payment_Gateway_Plugin $plugin */
 			$plugin = $this->plugin;
 
-			require_once( $plugin->get_payment_gateway_framework_path() . '/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php' );
+			require_once( $plugin->get_payment_gateway_framework_path() . '/Blocks/Gateway_Checkout_Block_Integration.php' );
 
 			foreach ( $plugin->get_gateways() as $gateway ) {
 

--- a/woocommerce/payment-gateway/Blocks/Gateway_Blocks_Handler.php
+++ b/woocommerce/payment-gateway/Blocks/Gateway_Blocks_Handler.php
@@ -59,7 +59,7 @@ class Gateway_Blocks_Handler extends Blocks_Handler {
 			/** @var SV_WC_Payment_Gateway_Plugin $plugin */
 			$plugin = $this->plugin;
 
-			require_once( $plugin->get_framework_path() . '/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php' );
+			require_once( $plugin->get_payment_gateway_framework_path() . '/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php' );
 
 			foreach ( $plugin->get_gateways() as $gateway ) {
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -181,8 +181,8 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	protected function init_blocks_handler() : void {
 
-		require_once( $this->get_payment_gateway_framework_path() . '/Blocks/Blocks_Handler.php' );
-		require_once( $this->get_payment_gateway_framework_path() . '/payment-gateway/Blocks/Gateway_Blocks_Handler.php' );
+		require_once( $this->get_framework_path() . '/Blocks/Blocks_Handler.php' );
+		require_once( $this->get_payment_gateway_framework_path() . '/Blocks/Gateway_Blocks_Handler.php' );
 
 		// individual gateway plugins should initialize their block integrations handler by overriding this method
 		$this->blocks_handler = new Gateway_Blocks_Handler( $this );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -181,8 +181,8 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 */
 	protected function init_blocks_handler() : void {
 
-		require_once( $this->get_framework_path() . '/Blocks/Blocks_Handler.php' );
-		require_once( $this->get_framework_path() . '/payment-gateway/Blocks/Gateway_Blocks_Handler.php' );
+		require_once( $this->get_payment_gateway_framework_path() . '/Blocks/Blocks_Handler.php' );
+		require_once( $this->get_payment_gateway_framework_path() . '/payment-gateway/Blocks/Gateway_Blocks_Handler.php' );
 
 		// individual gateway plugins should initialize their block integrations handler by overriding this method
 		$this->blocks_handler = new Gateway_Blocks_Handler( $this );


### PR DESCRIPTION
# Summary

Some FW files only exist in gateway plugins due to our build process. This change ensures that gateway plugins will load block handler files from the gateway FW path, rather than a generic FW path.

This fix is similar to https://github.com/gdcorp-partners/woocommerce-gateway-intuit-qbms/pull/11/files

### Story: [MWC-16371](https://godaddy-corp.atlassian.net/browse/MWC-16371)