### PR TITLE
Disable order saving when we're on the payment method page

### DIFF
--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,5 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
+2024.nn.nn - version 5.12.3
+ * Fix - Prevent blank orders from being generated when adding a payment method
+
 2024.06.03 - version 5.12.4
  * Fix - Ensure gateway scripts are compiled as regular JS rather than modules
  * Fix - Address an issue where multiple save buttons were displayed when editing a payment method in My Account

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,6 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
-2024.nn.nn - version 5.12.3
+2024.nn.nn - version 5.12.5
  * Fix - Prevent blank orders from being generated when adding a payment method
 
 2024.06.03 - version 5.12.4

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -593,11 +593,14 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * @since 1.0.0
 	 * @see SV_WC_Payment_Gateway::get_order()
 	 * @param int|\WC_Order $order_id order ID being processed
+	 * @param bool $adding_payment_method Whether we're in the context of adding a payment method. If set to `true` then
+	 *                                    this ensures the order in question is never saved. Saving the order when adding
+	 *                                    a payment method could result in blank orders persisting to the database.
 	 * @return \WC_Order object with payment and transaction information attached
 	 */
-	public function get_order( $order_id ) {
+	public function get_order( $order_id, bool $adding_payment_method = false ) {
 
-		$order = parent::get_order( $order_id );
+		$order = parent::get_order( $order_id, $adding_payment_method );
 
 		// payment info
 		if ( SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-account-number' ) && ! SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
@@ -1082,7 +1085,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 
 		// mock order, as all gateway API implementations require an order object for tokenization
 		$order = new \WC_Order( 0 );
-		$order = $this->get_order( $order );
+		$order = $this->get_order( $order, true );
 
 		$user = get_userdata( get_current_user_id() );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -593,14 +593,11 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * @since 1.0.0
 	 * @see SV_WC_Payment_Gateway::get_order()
 	 * @param int|\WC_Order $order_id order ID being processed
-	 * @param bool $adding_payment_method Whether we're in the context of adding a payment method. If set to `true` then
-	 *                                    this ensures the order in question is never saved. Saving the order when adding
-	 *                                    a payment method could result in blank orders persisting to the database.
 	 * @return \WC_Order object with payment and transaction information attached
 	 */
-	public function get_order( $order_id, bool $adding_payment_method = false ) {
+	public function get_order( $order_id ) {
 
-		$order = parent::get_order( $order_id, $adding_payment_method );
+		$order = parent::get_order( $order_id );
 
 		// payment info
 		if ( SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-account-number' ) && ! SV_WC_Helper::get_posted_value( 'wc-' . $this->get_id_dasherized() . '-payment-token' ) ) {
@@ -1085,7 +1082,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 
 		// mock order, as all gateway API implementations require an order object for tokenization
 		$order = new \WC_Order( 0 );
-		$order = $this->get_order( $order, true );
+		$order = $this->get_order( $order );
 
 		$user = get_userdata( get_current_user_id() );
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1949,6 +1949,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 			$order->save();
 		}
 
+		// the get_order_with_unique_transaction_ref() call results in saving the order object, which we don't want to do on the "add payment method" page
 		if ( ! is_add_payment_method_page() ) {
 			$order = $this->get_order_with_unique_transaction_ref($order);
 		}

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1944,8 +1944,8 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		/* translators: Placeholders: %1$s - site title, %2$s - order number */
 		$order->description = sprintf( esc_html__( '%1$s - Order %2$s', 'woocommerce-plugin-framework' ), wp_specialchars_decode( SV_WC_Helper::get_site_name(), ENT_QUOTES ), $order->get_order_number() );
 
-		// the get_order_with_unique_transaction_ref() call results in saving the order object, which we don't want to do on the "add payment method" page
-		if ( ! is_add_payment_method_page() ) {
+		// the get_order_with_unique_transaction_ref() call results in saving the order object, which we don't want to do if the order hasn't already been saved (such as when adding a payment method)
+		if ( $order->get_id() ) {
 			$order = $this->get_order_with_unique_transaction_ref($order);
 		}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1945,11 +1945,13 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		$order->description = sprintf( esc_html__( '%1$s - Order %2$s', 'woocommerce-plugin-framework' ), wp_specialchars_decode( SV_WC_Helper::get_site_name(), ENT_QUOTES ), $order->get_order_number() );
 
 		// when HPOS is enabled, we need to save the order to avoid potential errors when saving a new payment method
-		if ( SV_WC_Plugin_Compatibility::is_hpos_enabled() && ( ! is_admin() || is_ajax() ) ) {
+		if ( SV_WC_Plugin_Compatibility::is_hpos_enabled() && ( ! is_admin() || is_ajax() ) && ! is_add_payment_method_page() ) {
 			$order->save();
 		}
 
-		$order = $this->get_order_with_unique_transaction_ref( $order );
+		if ( ! is_add_payment_method_page() ) {
+			$order = $this->get_order_with_unique_transaction_ref($order);
+		}
 
 		/**
 		 * Filters the base order for a payment transaction.

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1944,11 +1944,6 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		/* translators: Placeholders: %1$s - site title, %2$s - order number */
 		$order->description = sprintf( esc_html__( '%1$s - Order %2$s', 'woocommerce-plugin-framework' ), wp_specialchars_decode( SV_WC_Helper::get_site_name(), ENT_QUOTES ), $order->get_order_number() );
 
-		// when HPOS is enabled, we need to save the order to avoid potential errors when saving a new payment method
-		if ( SV_WC_Plugin_Compatibility::is_hpos_enabled() && ( ! is_admin() || is_ajax() ) && ! is_add_payment_method_page() ) {
-			$order->save();
-		}
-
 		// the get_order_with_unique_transaction_ref() call results in saving the order object, which we don't want to do on the "add payment method" page
 		if ( ! is_add_payment_method_page() ) {
 			$order = $this->get_order_with_unique_transaction_ref($order);

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1946,7 +1946,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 
 		// the get_order_with_unique_transaction_ref() call results in saving the order object, which we don't want to do if the order hasn't already been saved (such as when adding a payment method)
 		if ( $order->get_id() ) {
-			$order = $this->get_order_with_unique_transaction_ref($order);
+			$order = $this->get_order_with_unique_transaction_ref( $order );
 		}
 
 		/**

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1917,9 +1917,12 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * @since 1.0.0
 	 *
 	 * @param int|\WC_Order $order the order or order ID being processed
+	 * @param bool $adding_payment_method Whether we're in the context of adding a payment method. If set to `true` then
+	 *                                    this ensures the order in question is never saved. Saving the order when adding
+	 *                                    a payment method could result in blank orders persisting to the database.
 	 * @return \WC_Order object with payment and transaction information attached
 	 */
-	public function get_order( $order ) {
+	public function get_order( $order, bool $adding_payment_method = false ) {
 
 		if ( is_numeric( $order ) ) {
 			$order = wc_get_order( $order );
@@ -1945,7 +1948,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		$order->description = sprintf( esc_html__( '%1$s - Order %2$s', 'woocommerce-plugin-framework' ), wp_specialchars_decode( SV_WC_Helper::get_site_name(), ENT_QUOTES ), $order->get_order_number() );
 
 		// the get_order_with_unique_transaction_ref() call results in saving the order object, which we don't want to do on the "add payment method" page
-		if ( ! is_add_payment_method_page() ) {
+		if ( ! $adding_payment_method ) {
 			$order = $this->get_order_with_unique_transaction_ref($order);
 		}
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -1917,12 +1917,9 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 * @since 1.0.0
 	 *
 	 * @param int|\WC_Order $order the order or order ID being processed
-	 * @param bool $adding_payment_method Whether we're in the context of adding a payment method. If set to `true` then
-	 *                                    this ensures the order in question is never saved. Saving the order when adding
-	 *                                    a payment method could result in blank orders persisting to the database.
 	 * @return \WC_Order object with payment and transaction information attached
 	 */
-	public function get_order( $order, bool $adding_payment_method = false ) {
+	public function get_order( $order ) {
 
 		if ( is_numeric( $order ) ) {
 			$order = wc_get_order( $order );
@@ -1948,7 +1945,7 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 		$order->description = sprintf( esc_html__( '%1$s - Order %2$s', 'woocommerce-plugin-framework' ), wp_specialchars_decode( SV_WC_Helper::get_site_name(), ENT_QUOTES ), $order->get_order_number() );
 
 		// the get_order_with_unique_transaction_ref() call results in saving the order object, which we don't want to do on the "add payment method" page
-		if ( ! $adding_payment_method ) {
+		if ( ! is_add_payment_method_page() ) {
 			$order = $this->get_order_with_unique_transaction_ref($order);
 		}
 


### PR DESCRIPTION
# Summary

This prevents us from saving the order object when we're on the "add payment method" page. We do this by ensuring we don't call any save methods if the order doesn't already have an ID number. When on the payment method page, we expect to be working with a `WC_Order` object that has a `0` ID which is why this works.

## Issue: [MWC-16645](https://godaddy-corp.atlassian.net/browse/MWC-16645) & [MWC-16316](https://godaddy-corp.atlassian.net/browse/MWC-16316)

## Details

The initial `$order->save()` method has been removed. This was added to avoid potential errors, but thus far we haven't been able to reproduce any errors with that line removed.

Using authorize.net I tested the following:

- Placing an order, using an existing/saved payment method; and
- Placing an order, using a brand new payment method

In both cases the order was created successfully and the charge went through.

## QA

### Authorize.net

See https://github.com/gdcorp-partners/woocommerce-gateway-authorize-net-cim/pull/98

1. Ensure you have authorize.net set up.
2. Add a product to your cart and proceed through to checkout.
3. Select the authorize.net payment gateway and add a new payment method. Complete the checkout.
    - [ ] A new order is created with all appropriate information.
    - [ ] Payment is taken successfully.
5. Go to your account area on the front-end and to the "payment methods" page. Click through to add a new payment method and complete the process.
6. Once added, log in as an admin and check the WooCommerce > Orders.
    - [ ] No new order has been created.

### Elavon

See https://github.com/gdcorp-partners/woocommerce-gateway-elavon/pull/94

1. Ensure you have Elavon set up and enabled.
2. Visit any page on the front end.
    - [ ] No new order is created.
3. Add a product to your cart and proceed through to checkout.
4. Select the Elavon payment gateway and complete your payment.
    - [ ] One new order is created with all appropriate information.
    - [ ] Payment is taken successfully.
5. Go to your account area on the front-end and to the "payment methods" page. Click through to add a new payment method and complete the process.
6. Once added, log in as an admin and check the WooCommerce > Orders.
    - [ ] No new order has been created.

## Before Merge

- [ ] Framework namespace and version is updated