### PR TITLE
PoC: Autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,11 @@
     "codeception/module-phpbrowser": "^1.0",
     "codeception/module-asserts": "^1.3"
   },
+  "autoload": {
+    "psr-4": {
+      "SkyVerge\\WooCommerce\\PluginFramework\\v5_12_7\\": "woocommerce/"
+    }
+  },
   "config": {
     "platform": {
       "php": "7.4"

--- a/woocommerce-framework-plugin-loader-sample.php
+++ b/woocommerce-framework-plugin-loader-sample.php
@@ -165,13 +165,15 @@ class SV_WC_Framework_Plugin_Loader {
 	 */
 	private function load_framework() {
 
+		require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+
 		if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\' . $this->get_framework_version_namespace() . '\\SV_WC_Plugin' ) ) {
-			require_once( plugin_dir_path( __FILE__ ) . 'lib/skyverge/woocommerce/class-sv-wc-plugin.php' );
+			require_once( plugin_dir_path( __FILE__ ) . 'vendor/skyverge/woocommerce/class-sv-wc-plugin.php' );
 		}
 
 		// TODO: remove this if not a payment gateway
 		if ( ! class_exists( '\\SkyVerge\\WooCommerce\\PluginFramework\\' . $this->get_framework_version_namespace() . '\\SV_WC_Payment_Gateway_Plugin' ) ) {
-			require_once( plugin_dir_path( __FILE__ ) . 'lib/skyverge/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php' );
+			require_once( plugin_dir_path( __FILE__ ) . 'vendor/skyverge/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php' );
 		}
 	}
 

--- a/woocommerce/Blocks/Blocks_Handler.php
+++ b/woocommerce/Blocks/Blocks_Handler.php
@@ -52,8 +52,8 @@ class Blocks_Handler {
 
 		$framework_path = $this->plugin->get_framework_path();
 
-		require_once( $framework_path . '/Blocks/Traits/Block_Integration_Trait.php' );
-		require_once( $framework_path . '/Blocks/Block_Integration.php' );
+		//require_once( $framework_path . '/Blocks/Traits/Block_Integration_Trait.php' );
+		//require_once( $framework_path . '/Blocks/Block_Integration.php' );
 
 		// blocks-related notices and call-to-actions
 		add_action( 'admin_notices', [ $this, 'add_admin_notices' ] );

--- a/woocommerce/Blocks/Traits/Block_Integration_Trait.php
+++ b/woocommerce/Blocks/Traits/Block_Integration_Trait.php
@@ -12,7 +12,7 @@ use SkyVerge\WooCommerce\PluginFramework\v5_12_7\SV_WC_Plugin;
 use SkyVerge\WooCommerce\PluginFramework\v5_12_7\SV_WC_Plugin_Exception;
 use stdClass;
 
-if ( ! class_exists( '\\SkyVerge\WooCommerce\PluginFramework\v5_12_7\Blocks\Traits\Block_Integration_Trait' ) ) :
+if ( ! trait_exists( '\\SkyVerge\WooCommerce\PluginFramework\v5_12_7\Blocks\Traits\Block_Integration_Trait' ) ) :
 
 /**
  * A trait for block integrations.

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -449,6 +449,9 @@ abstract class SV_WC_Plugin {
 
 		$framework_path = $this->get_framework_path();
 
+		// ideally the loader file has already done this, but we're adding it again just in case it was omitted
+		require_once $this->get_plugin_path().'/vendor/autoload.php';
+
 		// common exception class
 		require_once(  $framework_path . '/class-sv-wc-plugin-exception.php' );
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -466,7 +466,7 @@ abstract class SV_WC_Plugin {
 
 		// common utility methods
 		require_once( $framework_path . '/class-sv-wc-helper.php' );
-		require_once( $framework_path . '/Country_Helper.php' );
+		//require_once( $framework_path . '/Country_Helper.php' );
 		require_once( $framework_path . '/admin/Notes_Helper.php' );
 
 		// backwards compatibility for older WC versions
@@ -497,7 +497,7 @@ abstract class SV_WC_Plugin {
 		require_once( $framework_path . '/rest-api/Controllers/Settings.php' );
 
 		// Handlers
-		require_once( $framework_path . '/Handlers/Script_Handler.php' );
+		//require_once( $framework_path . '/Handlers/Script_Handler.php' );
 		require_once( $framework_path . '/class-sv-wc-plugin-dependencies.php' );
 		require_once( $framework_path . '/class-sv-wc-hook-deprecator.php' );
 		require_once( $framework_path . '/class-sv-wp-admin-message-handler.php' );


### PR DESCRIPTION
# Summary

Sets up autoloading for the plugin namespace. For now this is only meant to work with newly added files -- not existing ones.

## Details

I have commented out a few `require_once` calls for classes that should now be covered by autoloading -- just to test they still get loaded.

## QA

MPC has a draft PR to test this version of the framework https://github.com/gdcorp-partners/woocommerce-measurement-price-calculator/pull/110

### Setup

- Checkout https://github.com/gdcorp-partners/woocommerce-measurement-price-calculator/pull/110
- Run `composer update skyverge/wc-plugin-framework`
- Ensure all over SkyVerge plugins are deactivated (just to ensure we _know_ that we're testing the framework loaded via this single plugin)

### Steps

1. Load any wp-admin page
    - [x] No fatal errors
2. Execute this code: `var_dump(class_exists('\\SkyVerge\\WooCommerce\\PluginFramework\\v5_12_7\\Country_Helper'));` (this is a class file we're no longer manually requiring)
    - [x] It outputs `true`

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
