### PR TITLE
Add `CanGetNewInstanceTrait`

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,7 @@ require_once PLUGIN_ROOT_DIR.'/woocommerce/class-sv-wc-plugin.php';
 require_once PLUGIN_ROOT_DIR.'/woocommerce/class-sv-wc-plugin-exception.php';
 require_once PLUGIN_ROOT_DIR.'/woocommerce/Enums/Traits/EnumTrait.php';
 require_once PLUGIN_ROOT_DIR.'/woocommerce/Enums/PaymentFormContext.php';
+require_once PLUGIN_ROOT_DIR.'/woocommerce/Traits/CanGetNewInstanceTrait.php';
 require_once PLUGIN_ROOT_DIR.'/woocommerce/Traits/IsSingletonTrait.php';
 
 WP_Mock::setUsePatchwork(true);

--- a/tests/unit/Traits/CanGetNewInstanceTraitTest.php
+++ b/tests/unit/Traits/CanGetNewInstanceTraitTest.php
@@ -8,17 +8,32 @@ use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanGetNewInstanceTrait;
 class CanGetNewInstanceTraitTest extends TestCase
 {
 	/**
-	 * Tests that it can get new instance.
+	 * Tests that it can get new instance with arguments.
 	 *
 	 * @covers \SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanGetNewInstanceTrait::getNewInstance()
 	 */
-	public function testItCanGetNewInstance()
+	public function testItCanGetNewInstanceWithArgs() : void
 	{
 		$class = $this->getTestClass();
 		$newInstance = $class::getNewInstance('value1', 'value2');
 
 		$this->assertSame('value1', $newInstance->arg1);
 		$this->assertSame('value2', $newInstance->arg2);
+		$this->assertInstanceOf(get_class($class), $newInstance);
+	}
+
+	/**
+	 * Tests that it can get new instance without arguments.
+	 *
+	 * @covers \SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanGetNewInstanceTrait::getNewInstance()
+	 */
+	public function testItCanGetNewInstanceWithoutArgs() : void
+	{
+		$class = $this->getTestClass();
+		$newInstance = $class::getNewInstance();
+
+		$this->assertNull($newInstance->arg1);
+		$this->assertNull($newInstance->arg2);
 		$this->assertInstanceOf(get_class($class), $newInstance);
 	}
 
@@ -32,10 +47,10 @@ class CanGetNewInstanceTraitTest extends TestCase
 		return new class {
 			use CanGetNewInstanceTrait;
 
-			public $arg1;
-			public $arg2;
+			public ?string $arg1 = null;
+			public ?string $arg2 = null;
 
-			public function __construct($arg1 = null, $arg2 = null)
+			public function __construct(?string $arg1 = null, ?string $arg2 = null)
 			{
 				$this->arg1 = $arg1;
 				$this->arg2 = $arg2;

--- a/tests/unit/Traits/CanGetNewInstanceTraitTest.php
+++ b/tests/unit/Traits/CanGetNewInstanceTraitTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\Unit\Traits;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\TestCase;
+use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanGetNewInstanceTrait;
+
+class CanGetNewInstanceTraitTest extends TestCase
+{
+	/**
+	 * Tests that it can get new instance.
+	 *
+	 * @covers \SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanGetNewInstanceTrait::getNewInstance()
+	 */
+	public function testItCanGetNewInstance()
+	{
+		$class = $this->getTestClass();
+		$newInstance = $class::getNewInstance('value1', 'value2');
+
+		$this->assertSame('value1', $newInstance->arg1);
+		$this->assertSame('value2', $newInstance->arg2);
+		$this->assertInstanceOf(get_class($class), $newInstance);
+	}
+
+	/**
+	 * Anonymous Class for Testing Trait.
+	 *
+	 * @see testItCanGetNewInstance
+	 */
+	private function getTestClass()
+	{
+		return new class {
+			use CanGetNewInstanceTrait;
+
+			public $arg1;
+			public $arg2;
+
+			public function __construct($arg1 = null, $arg2 = null)
+			{
+				$this->arg1 = $arg1;
+				$this->arg2 = $arg2;
+			}
+		};
+	}
+}

--- a/woocommerce/Traits/CanGetNewInstanceTrait.php
+++ b/woocommerce/Traits/CanGetNewInstanceTrait.php
@@ -24,8 +24,6 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits;
 
-use ReflectionClass;
-
 defined('ABSPATH') or exit;
 
 if (trait_exists('\\SkyVerge\\WooCommerce\\PluginFramework\\v5_13_1\\Traits\\CanGetNewInstanceTrait')) {
@@ -43,8 +41,8 @@ trait CanGetNewInstanceTrait
 	 *
 	 * @return static
 	 */
-	public static function getNewInstance()
+	public static function getNewInstance(...$args)
 	{
-		return (new ReflectionClass(static::class))->newInstanceArgs(func_get_args());
+		return new static(...$args);
 	}
 }

--- a/woocommerce/Traits/CanGetNewInstanceTrait.php
+++ b/woocommerce/Traits/CanGetNewInstanceTrait.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2024, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits;
+
+use ReflectionClass;
+
+defined('ABSPATH') or exit;
+
+if (trait_exists('\\SkyVerge\\WooCommerce\\PluginFramework\\v5_13_1\\Traits\\CanGetNewInstanceTrait')) {
+	return;
+}
+
+/**
+ * A trait that allows a given class/object to get a new instance of itself.
+ * For singletons {@see CanGetNewInstanceTrait} instead.
+ */
+trait CanGetNewInstanceTrait
+{
+	/**
+	 * Creates and returns a new instance of the calling class.
+	 *
+	 * @return static
+	 */
+	public static function getNewInstance()
+	{
+		return (new ReflectionClass(static::class))->newInstanceArgs(func_get_args());
+	}
+}

--- a/woocommerce/Traits/IsSingletonTrait.php
+++ b/woocommerce/Traits/IsSingletonTrait.php
@@ -50,9 +50,9 @@ trait IsSingletonTrait
 	 *
 	 * @return static
 	 */
-	public static function getInstance()
+	public static function getInstance(...$args)
 	{
-		return static::$instance ??= new static(...func_get_args());
+		return static::$instance ??= new static(...$args);
 	}
 
 	/**

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,7 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2024.nn.nn - version 5.13.1-dev.1
-* Feature - Add a trait to get a singular instance of a class IsSingletonTrait
+* Feature - Add a trait to get a singular instance of a class: `IsSingletonTrait`
+* Feature - Add a trait to get an instance (non-singular) of a class: `CanGetNewInstanceTrait`
 
 2024.08.21 - version 5.13.0
  * Feature - Add a trait for enum-like classes

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -452,6 +452,10 @@ abstract class SV_WC_Plugin {
 		// common exception class
 		require_once(  $framework_path . '/class-sv-wc-plugin-exception.php' );
 
+		// traits
+		require_once(  $framework_path . '/Traits/CanGetNewInstanceTrait.php' );
+		require_once(  $framework_path . '/Traits/IsSingletonTrait.php' );
+
 		// addresses
 		require_once(  $framework_path . '/Addresses/Address.php' );
 		require_once(  $framework_path . '/Addresses/Customer_Address.php' );


### PR DESCRIPTION
# Summary

Release: https://github.com/godaddy-wordpress/wc-plugin-framework/pull/699

This adds the `CanGetNewInstanceTrait`

## QA

- [ ] Code review
- [ ] Checks pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
