### PR TITLE
[WIP] Add `CanConvertToArrayTrait` and `ArrayHelper` classes

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,8 @@ require_once PLUGIN_ROOT_DIR.'/woocommerce/class-sv-wc-plugin.php';
 require_once PLUGIN_ROOT_DIR.'/woocommerce/class-sv-wc-plugin-exception.php';
 require_once PLUGIN_ROOT_DIR.'/woocommerce/Enums/Traits/EnumTrait.php';
 require_once PLUGIN_ROOT_DIR.'/woocommerce/Enums/PaymentFormContext.php';
+require_once PLUGIN_ROOT_DIR.'/woocommerce/Helpers/ArrayHelper.php';
+require_once PLUGIN_ROOT_DIR.'/woocommerce/Traits/CanConvertToArrayTrait.php';
 require_once PLUGIN_ROOT_DIR.'/woocommerce/Traits/IsSingletonTrait.php';
 
 WP_Mock::setUsePatchwork(true);

--- a/tests/unit/Helpers/ArrayHelperTest.php
+++ b/tests/unit/Helpers/ArrayHelperTest.php
@@ -115,11 +115,52 @@ final class ArrayHelperTest extends TestCase
 	}
 
 	/**
+	 * Tests that can remove items from an array.
+	 *
 	 * @covers ::remove()
+	 * @dataProvider providerCanRemove
+	 *
+	 * @param array<string, mixed> $input
+	 * @param string|string[] $keysToRemove
+	 * @param array $expected
 	 */
-	public function testCanRemove(): void
+	public function testCanRemoveItemsFromArray(array $input, $keysToRemove, array $expected) : void
 	{
-		$this->markTestIncomplete('TODO');
+		ArrayHelper::remove($input, $keysToRemove);
+		$this->assertEquals($expected, $input);
+	}
+
+	/** @see testCanRemoveItemsFromArray */
+	public function providerCanRemove() : Generator
+	{
+		yield 'remove 1 key from one item array' => [
+			'input'        => ['test' => 1],
+			'keysToRemove' => 'test',
+			'expected'     => [],
+		];
+
+		yield 'remove 1 key from two item array' => [
+			'input'        => ['test' => 2, 'second' => ['nested' => 3]],
+			'keysToRemove' => 'second',
+			'expected'     => ['test' => 2],
+		];
+
+		yield 'remove 2 keys' => [
+			'input'        => ['test' => 2, 'second' => ['nested' => 3], 'third' => 4],
+			'keysToRemove' => ['second', 'third'],
+			'expected'     => ['test' => 2],
+		];
+
+		yield 'remove 2 keys that are one level deep' => [
+			'input' => [
+				'resource' => [
+					'first'  => 1,
+					'second' => 2,
+				],
+			],
+			'keysToRemove' => ['resource.first', 'resource.second'],
+			'expected'     => ['resource' => []],
+		];
 	}
 
 	/**
@@ -215,22 +256,22 @@ final class ArrayHelperTest extends TestCase
 		return new class implements ArrayAccess
 		{
 
-			public function offsetExists($offset)
+			public function offsetExists($offset) : bool
 			{
 				return true;
 			}
 
-			public function offsetGet($offset)
+			public function offsetGet($offset) : int
 			{
 				return 1;
 			}
 
-			public function offsetSet($offset, $value)
+			public function offsetSet($offset, $value) : void
 			{
 				// TODO: Implement offsetSet() method.
 			}
 
-			public function offsetUnset($offset)
+			public function offsetUnset($offset) : void
 			{
 				// TODO: Implement offsetUnset() method.
 			}

--- a/tests/unit/Helpers/ArrayHelperTest.php
+++ b/tests/unit/Helpers/ArrayHelperTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\Unit\Helpers;
+
+use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \SkyVerge\WooCommerce\PluginFramework\v5_13_1\Helpers\ArrayHelper
+ */
+final class ArrayHelperTest extends TestCase
+{
+
+}

--- a/tests/unit/Helpers/ArrayHelperTest.php
+++ b/tests/unit/Helpers/ArrayHelperTest.php
@@ -2,6 +2,9 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\Unit\Helpers;
 
+use ArrayAccess;
+use Generator;
+use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Helpers\ArrayHelper;
 use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\TestCase;
 
 /**
@@ -9,5 +12,228 @@ use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\TestCase;
  */
 final class ArrayHelperTest extends TestCase
 {
+	/**
+	 * @covers ::accessible()
+	 * @dataProvider providerCanDetermineIsAccessible
+	 *
+	 * @param mixed $item
+	 * @param bool $expected
+	 * @return void
+	 */
+	public function testCanDetermineIsAccessible($item, bool $expected): void
+	{
+		$this->assertSame($expected, ArrayHelper::accessible($item));
+	}
 
+	/** @see testCanDetermineIsAccessible */
+	public function providerCanDetermineIsAccessible(): Generator
+	{
+		yield 'array is accessible' => [
+			'item' => ['foo' => 'bar'],
+			'expected' => true,
+		];
+
+		yield 'ArrayAccess is accessible' => [
+			'item' => $this->getArrayAccessObject(),
+			'expected' => true,
+		];
+
+		yield 'object without ArrayAccess is not accessible' => [
+			'item' => new \stdClass(),
+			'expected' => false,
+		];
+
+		yield 'integer is not accessible' => [
+			'item' => 10,
+			'expected' => false,
+		];
+
+		yield 'string is not accessible' => [
+			'item' => 'string',
+			'expected' => false,
+		];
+	}
+
+	/**
+	 * @covers ::except()
+	 * @dataProvider providerExcept
+	 *
+	 * @param array $inputArray
+	 * @param array|string $keysToExclude
+	 * @param array $expectedOutputArray
+	 * @return void
+	 */
+	public function testExcept(array $inputArray, $keysToExclude, array $expectedOutputArray): void
+	{
+		$this->assertSame(
+			$expectedOutputArray,
+			ArrayHelper::except($inputArray, $keysToExclude)
+		);
+	}
+
+	/** @see testExcept */
+	public function providerExcept(): Generator
+	{
+		yield 'array of keys' => [
+			'inputArray' => [
+				'apple' => 'red',
+				'banana' => 'yellow',
+				'cucumber' => 'green',
+			],
+			'keysToExclude' => ['apple', 'cucumber'],
+			'expectedOutputArray' => [
+				'banana' => 'yellow',
+			],
+		];
+
+		yield 'key as a string' => [
+			'inputArray' => [
+				'apple' => 'red',
+				'banana' => 'yellow',
+				'cucumber' => 'green',
+			],
+			'keysToExclude' => 'banana',
+			'expectedOutputArray' => [
+				'apple' => 'red',
+				'cucumber' => 'green',
+			],
+		];
+
+		yield 'keys to exclude do not exist' => [
+			'inputArray' => [
+				'apple' => 'red',
+				'banana' => 'yellow',
+				'cucumber' => 'green',
+			],
+			'keysToExclude' => ['invalid'],
+			'expectedOutputArray' => [
+				'apple' => 'red',
+				'banana' => 'yellow',
+				'cucumber' => 'green',
+			],
+		];
+	}
+
+	/**
+	 * @covers ::remove()
+	 */
+	public function testCanRemove(): void
+	{
+		$this->markTestIncomplete('TODO');
+	}
+
+	/**
+	 * @covers ::wrap()
+	 * @dataProvider providerCanWrap
+	 *
+	 * @param mixed $item
+	 * @param array $expectedOutput
+	 * @return void
+	 */
+	public function testCanWrap($item, array $expectedOutput): void
+	{
+		$this->assertEquals($expectedOutput, ArrayHelper::wrap($item));
+	}
+
+	/** @see testCanWrap */
+	public function providerCanWrap(): Generator
+	{
+		yield 'already an array' => [
+			'item' => ['foo' => 'bar'],
+			'expectedOutput' => ['foo' => 'bar'],
+		];
+
+		yield 'integer' => [
+			'item' => 50,
+			'expectedOutput' => [50],
+		];
+
+		yield 'null item' => [
+			'item' => null,
+			'expectedOutput' => [],
+		];
+
+		yield 'empty string' => [
+			'item' => '',
+			'expectedOutput' => [],
+		];
+	}
+
+	/**
+	 * @covers ::exists()
+	 * @dataProvider providerCanDetermineKeyExists
+	 *
+	 * @param array|ArrayAccess $input
+	 * @param string|int $key
+	 * @param bool $expected
+	 * @return void
+	 */
+	public function testCanDetermineKeyExists($input, $key, bool $expected): void
+	{
+		$this->assertSame(
+			$expected,
+			ArrayHelper::exists($input, $key)
+		);
+	}
+
+	/** @see testCanDetermineKeyExists */
+	public function providerCanDetermineKeyExists(): Generator
+	{
+		yield 'ArrayAccess' => [
+			'input' => $this->getArrayAccessObject(),
+			'key' => 'key',
+			'expected' => true,
+		];
+
+		yield 'array with string key that exists' => [
+			'input' => ['foo' => 'bar'],
+			'key' => 'foo',
+			'expected' => true,
+		];
+
+		yield 'array with string key that does not exist' => [
+			'input' => ['foo' => 'bar'],
+			'key' => 'invalid',
+			'expected' => false,
+		];
+
+		yield 'array with integer key that exists' => [
+			'input' => ['chocolate', 'vanilla'],
+			'key' => 1,
+			'expected' => true,
+		];
+
+		yield 'array with integer key that does not exist' => [
+			'input' => ['chocolate', 'vanilla'],
+			'key' => 5,
+			'expected' => false,
+		];
+	}
+
+	protected function getArrayAccessObject(): ArrayAccess
+	{
+		return new class implements ArrayAccess
+		{
+
+			public function offsetExists($offset)
+			{
+				return true;
+			}
+
+			public function offsetGet($offset)
+			{
+				return 1;
+			}
+
+			public function offsetSet($offset, $value)
+			{
+				// TODO: Implement offsetSet() method.
+			}
+
+			public function offsetUnset($offset)
+			{
+				// TODO: Implement offsetUnset() method.
+			}
+		};
+	}
 }

--- a/tests/unit/Traits/CanConvertToArrayTraitTest.php
+++ b/tests/unit/Traits/CanConvertToArrayTraitTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\Unit\Traits;
+
+use Exception;
+use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Tests\TestCase;
+use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanConvertToArrayTrait;
+use stdClass;
+
+final class CanConvertToArrayTraitTest extends TestCase
+{
+	protected TestCanConvertToArray $subject;
+
+	public function setUp() : void
+	{
+		parent::setUp();
+
+		$this->subject = new TestCanConvertToArray();
+	}
+
+	/**
+	 * @covers \SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanConvertToArrayTrait::toArray()
+	 * @covers \SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanConvertToArrayTrait::toArrayShouldPropertyBeAccessible()
+	 *
+	 * @dataProvider providerCanConvertPropertiesToArray
+	 *
+	 * @param bool $includePrivateProperties
+	 * @param bool $includeProtectedProperties
+	 * @param bool $includePublicProperties
+	 * @param array $expectedProperties
+	 * @return void
+	 * @throws Exception
+	 */
+	public function testCanConvertPropertiesToArray(
+		bool $includePrivateProperties,
+		bool $includeProtectedProperties,
+		bool $includePublicProperties,
+		array $expectedProperties
+	) {
+		$this->setInaccessiblePropertyValue($this->subject, 'toArrayIncludePrivate', $includePrivateProperties);
+		$this->setInaccessiblePropertyValue($this->subject, 'toArrayIncludeProtected', $includeProtectedProperties);
+		$this->setInaccessiblePropertyValue($this->subject, 'toArrayIncludePublic', $includePublicProperties);
+
+		$this->assertSame($expectedProperties, $this->subject->toArray());
+	}
+
+	/** @see testCanConvertPropertiesToArray */
+	public function providerCanConvertPropertiesToArray(): \Generator
+	{
+		yield 'no properties included' => [
+			'includePrivateProperties' => false,
+			'includeProtectedProperties' => false,
+			'includePublicProperties' => false,
+			'expectedProperties' => [],
+		];
+
+		yield 'private properties included' => [
+			'includePrivateProperties' => true,
+			'includeProtectedProperties' => false,
+			'includePublicProperties' => false,
+			'expectedProperties' => [
+				'privateProperty' => 'private',
+			],
+		];
+
+		yield 'private and protected properties included' => [
+			'includePrivateProperties' => true,
+			'includeProtectedProperties' => true,
+			'includePublicProperties' => false,
+			'expectedProperties' => [
+				'privateProperty' => 'private',
+				'protectedProperty' => 'protected',
+			],
+		];
+
+		yield 'private, protected, and public properties included' => [
+			'includePrivateProperties' => true,
+			'includeProtectedProperties' => true,
+			'includePublicProperties' => true,
+			'expectedProperties' => [
+				'privateProperty' => 'private',
+				'protectedProperty' => 'protected',
+				'publicProperty' => 'public',
+			],
+		];
+
+		yield 'private and public properties included' => [
+			'includePrivateProperties' => true,
+			'includeProtectedProperties' => false,
+			'includePublicProperties' => true,
+			'expectedProperties' => [
+				'privateProperty' => 'private',
+				'publicProperty' => 'public',
+			],
+		];
+
+		yield 'protected and public properties included' => [
+			'includePrivateProperties' => false,
+			'includeProtectedProperties' => true,
+			'includePublicProperties' => true,
+			'expectedProperties' => [
+				'protectedProperty' => 'protected',
+				'publicProperty' => 'public',
+			],
+		];
+	}
+
+	/**
+	 * @covers \SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanConvertToArrayTrait::toArray()
+	 */
+	public function testCanConvertNestedProperties(): void
+	{
+		$this->markTestIncomplete('TODO');
+	}
+
+	/**
+	 * Tests that can determine whether an item can be converted to array.
+	 *
+	 * @covers \SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits\CanConvertToArrayTrait::canConvertItemToArray()
+	 *
+	 * @throws Exception
+	 */
+	public function testCanDetermineWhetherCanConvertItemToArray()
+	{
+		$trait = $this->getMockForTrait(CanConvertToArrayTrait::class);
+		$method = $this->getInaccessibleMethod($trait, 'canConvertItemToArray');
+
+		$this->assertFalse($method->invokeArgs($trait, [null]));
+		$this->assertFalse($method->invokeArgs($trait, ['foo']));
+		$this->assertFalse($method->invokeArgs($trait, [['foo' => 'bar']]));
+		$this->assertFalse($method->invokeArgs($trait, [123]));
+		$this->assertFalse($method->invokeArgs($trait, [new stdClass()]));
+		$this->assertTrue($method->invokeArgs($trait, [new class() {
+			public function toArray()
+			{
+				return [];
+			}
+		}]));
+	}
+}
+
+/** Dummy class for testing {@see CanConvertToArrayTrait} */
+final class TestCanConvertToArray
+{
+	use CanConvertToArrayTrait;
+
+	private string $privateProperty = 'private';
+	protected string $protectedProperty = 'protected';
+	public string $publicProperty = 'public';
+
+	/** @var bool this property should never be included in arrays because it's not initialized */
+	public bool $unInitializedProperty;
+}

--- a/woocommerce/Helpers/ArrayHelper.php
+++ b/woocommerce/Helpers/ArrayHelper.php
@@ -62,7 +62,7 @@ class ArrayHelper
 	 * @param array $array
 	 * @param array|string $keys
 	 */
-	public static function remove(array &$array, $keys)
+	public static function remove(array &$array, $keys) : void
 	{
 		$original = &$array;
 

--- a/woocommerce/Helpers/ArrayHelper.php
+++ b/woocommerce/Helpers/ArrayHelper.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2024, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_13_1\Helpers;
+
+use ArrayAccess;
+
+class ArrayHelper
+{
+	/**
+	 * Determines if a given item is an accessible array.
+	 *
+	 * @param mixed $value
+	 * @return bool
+	 * @phpstan-return ($value is array ? true : false)
+	 */
+	public static function accessible($value) : bool
+	{
+		return is_array($value) || $value instanceof ArrayAccess;
+	}
+
+	/**
+	 * Gets an array excluding the given keys.
+	 *
+	 * @param array $array
+	 * @param array|string $keys
+	 * @return array
+	 */
+	public static function except(array $array, $keys) : array
+	{
+		$temp = $array;
+
+		static::remove($temp, static::wrap($keys));
+
+		return $temp;
+	}
+
+	/**
+	 * Removes a given key or keys from the original array.
+	 *
+	 * @param array $array
+	 * @param array|string $keys
+	 */
+	public static function remove(array &$array, $keys)
+	{
+		$original = &$array;
+
+		foreach (static::wrap($keys) as $key) {
+			// if the key exists at this level unset and bail
+			if (static::exists($array, $key)) {
+				unset($array[$key]);
+
+				continue;
+			}
+
+			$parts = explode('.', $key);
+
+			// clean up before each pass
+			$array = &$original;
+
+			while (count($parts) > 1) {
+				$part = array_shift($parts);
+
+				if (isset($array[$part]) && is_array($array[$part])) {
+					$array = &$array[$part];
+				} else {
+					continue 2;
+				}
+			}
+
+			unset($array[array_shift($parts)]);
+		}
+	}
+
+	/**
+	 * Wraps a given item in an array if it is not an array.
+	 *
+	 * @param mixed $item
+	 * @return array
+	 */
+	public static function wrap($item = null) : array
+	{
+		if (is_array($item)) {
+			return $item;
+		}
+
+		return $item ? [$item] : [];
+	}
+
+	/**
+	 * Determines if an array key exists.
+	 *
+	 * @param ArrayAccess|array<mixed> $array
+	 * @param string|int $key
+	 * @return bool
+	 */
+	public static function exists($array, $key) : bool
+	{
+		if ($array instanceof ArrayAccess) {
+			return $array->offsetExists($key);
+		}
+
+		return array_key_exists($key, self::wrap($array));
+	}
+}

--- a/woocommerce/Traits/CanConvertToArrayTrait.php
+++ b/woocommerce/Traits/CanConvertToArrayTrait.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2024, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_13_1\Traits;
+
+use ReflectionClass;
+use ReflectionProperty;
+use SkyVerge\WooCommerce\PluginFramework\v5_13_1\Helpers\ArrayHelper;
+
+/**
+ * A trait that allows a given class/object to convert its state to an array.
+ */
+trait CanConvertToArrayTrait
+{
+	/** @var bool convert Private Properties to Array Output */
+	protected bool $toArrayIncludePrivate = false;
+
+	/** @var bool convert Protected Properties to Array Output */
+	protected bool $toArrayIncludeProtected = true;
+
+	/** @var bool convert Public Properties to Array Output */
+	protected bool $toArrayIncludePublic = true;
+
+	/** @var bool prevents infinite recursive calls */
+	private bool $bailIfInRecursiveCall = false;
+
+	/**
+	 * Converts all class data properties to an array.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function toArray() : array
+	{
+		if ($this->bailIfInRecursiveCall) {
+			return [];
+		}
+
+		$this->bailIfInRecursiveCall = true;
+
+		$array = [];
+
+		foreach ((new ReflectionClass(static::class))->getProperties() as $property) {
+			if ($this->toArrayShouldPropertyBeAccessible($property)) {
+				$property->setAccessible(true);
+
+				$propertyValue = $property->getValue($this);
+
+				$value = $propertyValue;
+
+				if ($this->canConvertItemToArray($propertyValue)) {
+					/** @phpstan-ignore-next-line PhpStan might not understand that the check above means the object has a toArray() method */
+					$value = $propertyValue->toArray();
+				} elseif (ArrayHelper::accessible($value)) {
+					$trait = $this;
+					/* @phpstan-ignore-next-line */
+					array_walk($value, static function (&$item) use ($trait) {
+						$item = $trait->canConvertItemToArray($item) ? $item->toArray() : $item;
+					});
+				}
+
+				$array[$property->getName()] = $value;
+			}
+		}
+
+		$this->bailIfInRecursiveCall = false;
+
+		return ArrayHelper::except($array, [
+			'bailIfInRecursiveCall',
+			'toArrayIncludePrivate',
+			'toArrayIncludeProtected',
+			'toArrayIncludePublic',
+		]);
+	}
+
+	/**
+	 * Determines if an item can be converted to an array.
+	 *
+	 * @param mixed $item
+	 * @return bool
+	 */
+	protected function canConvertItemToArray($item) : bool
+	{
+		return is_object($item) && is_callable([$item, 'toArray']);
+	}
+
+	/**
+	 * Checks if the property is accessible for {@see toArray()} conversion.
+	 *
+	 * @param ReflectionProperty $property
+	 * @return bool
+	 */
+	private function toArrayShouldPropertyBeAccessible(ReflectionProperty $property) : bool
+	{
+		// Force accessible for typed properties in PHP <8.1 to avoid an exception from isInitialized()
+		$property->setAccessible(true);
+
+		if (! $property->isInitialized($this)) {
+			return false;
+		}
+
+		if ($this->toArrayIncludePublic && $property->isPublic()) {
+			return true;
+		}
+
+		if ($this->toArrayIncludeProtected && $property->isProtected()) {
+			return true;
+		}
+
+		if ($this->toArrayIncludePrivate && $property->isPrivate()) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -2,6 +2,8 @@
 
 2024.nn.nn - version 5.13.1-dev.1
 * Feature - Add a trait to get a singular instance of a class IsSingletonTrait
+* Feature - Add a trait to convert an object into an array: `CanConvertToArrayTrait`
+* Feature - Add a new `ArrayHelper` class for array-related utility methods
 
 2024.08.21 - version 5.13.0
  * Feature - Add a trait for enum-like classes

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -452,6 +452,12 @@ abstract class SV_WC_Plugin {
 		// common exception class
 		require_once(  $framework_path . '/class-sv-wc-plugin-exception.php' );
 
+		// traits
+		require_once(  $framework_path . '/Traits/CanConvertToArrayTrait.php' );
+
+		// helpers
+		require_once(  $framework_path . '/Helpers/ArrayHelper.php' );
+
 		// addresses
 		require_once(  $framework_path . '/Addresses/Address.php' );
 		require_once(  $framework_path . '/Addresses/Customer_Address.php' );


### PR DESCRIPTION
# Summary

Release: https://github.com/godaddy-wordpress/wc-plugin-framework/pull/699

The main goal of this PR was to add the `CanConvertToArrayTrait`. Our existing implementation of this uses several methods from `ArrayHelper` so I copied over those as well. For now I only copied over the methods the trait actually needs. I'm not opposed to adding the rest, I just did it like this because I was also rewriting the tests (ones in mwc-common are kind of old) so I was reducing the amount of work required there in one go.

Note that the framework does already have some array helpers [starting here](https://github.com/godaddy-wordpress/wc-plugin-framework/blob/master/woocommerce/class-sv-wc-helper.php#L270). I propose we eventually follow up with another PR to start moving those methods over to the new `ArrayHelper` class (forwarding the old methods to the new for backwards compatibility). Again just didn't do that in this PR to keep this one smaller.



## QA

_If applicable, add specific steps for the reviewer to perform as part of their QA process prior to approving this pull request. Steps should be in a step -> success? format, like below_

### Setup

_List any configuration requirements for testing_

- This setting is configured
- Taxes are enabled

### Steps

Steps should be in a step => success? format, like below:

1. Do this
1. And this
	- [ ] The result is this

- [ ] Code review

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
