### PR TITLE
Account for Subscriptions Core library when checking for Subscriptions

### DIFF
--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -324,22 +324,31 @@ class SV_WC_Plugin_Compatibility {
 	 */
 	protected static function get_wc_subscriptions_version() : ?string {
 
+		$version = null;
+
 		if ( class_exists( 'WC_Subscriptions' ) && ! empty( \WC_Subscriptions::$version ) ) {
-			return \WC_Subscriptions::$version;
+			$version = \WC_Subscriptions::$version;
 		}
 
-		if ( class_exists( 'WC_Subscriptions_Core_Plugin' ) ) {
+		if ( ! $version && class_exists( 'WC_Subscriptions_Core_Plugin' ) ) {
 			 if ( is_callable( [ \WC_Subscriptions_Core_Plugin::class, 'instance' ] ) ) {
 
 				 $instance = \WC_Subscriptions_Core_Plugin::instance();
 
 				 if ( is_object( $instance ) && method_exists( $instance, 'get_library_version' ) ) {
-					 return $instance->get_library_version();
+					 $version = $instance->get_library_version();
 				 }
 			 }
 		}
 
-		return null;
+		/**
+		 * Filters the WooCommerce Subscriptions version when fetched by the framework.
+		 *
+		 * This accounts for cases where the version is not found by the framework as Subscriptions may be embedded as a core library by third party code.
+		 *
+		 * @param string $version WooCommerce Subscriptions version
+		 */
+		return (string) apply_filters( 'sv_wc_plugin_framework_wc_subscriptions_version', $version );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -346,9 +346,9 @@ class SV_WC_Plugin_Compatibility {
 		 *
 		 * This accounts for cases where the version is not found by the framework as Subscriptions may be embedded as a core library by third party code.
 		 *
-		 * @param string $version WooCommerce Subscriptions version
+		 * @param string|null $version WooCommerce Subscriptions version
 		 */
-		return (string) apply_filters( 'sv_wc_plugin_framework_wc_subscriptions_version', $version );
+		return apply_filters( 'sv_wc_plugin_framework_wc_subscriptions_version', $version );
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -328,9 +328,7 @@ class SV_WC_Plugin_Compatibility {
 
 		if ( class_exists( 'WC_Subscriptions' ) && ! empty( \WC_Subscriptions::$version ) ) {
 			$version = \WC_Subscriptions::$version;
-		}
-
-		if ( ! $version && class_exists( 'WC_Subscriptions_Core_Plugin' ) ) {
+		} elseif ( class_exists( 'WC_Subscriptions_Core_Plugin' ) ) {
 			 if ( is_callable( [ \WC_Subscriptions_Core_Plugin::class, 'instance' ] ) ) {
 
 				 $instance = \WC_Subscriptions_Core_Plugin::instance();

--- a/woocommerce/class-sv-wc-plugin-compatibility.php
+++ b/woocommerce/class-sv-wc-plugin-compatibility.php
@@ -322,9 +322,24 @@ class SV_WC_Plugin_Compatibility {
 	 *
 	 * @return string|null WooCommerce Subscriptions version number or null if not found
 	 */
-	protected static function get_wc_subscriptions_version() {
+	protected static function get_wc_subscriptions_version() : ?string {
 
-		return class_exists( 'WC_Subscriptions' ) && ! empty( \WC_Subscriptions::$version ) ? \WC_Subscriptions::$version : null;
+		if ( class_exists( 'WC_Subscriptions' ) && ! empty( \WC_Subscriptions::$version ) ) {
+			return \WC_Subscriptions::$version;
+		}
+
+		if ( class_exists( 'WC_Subscriptions_Core_Plugin' ) ) {
+			 if ( is_callable( [ \WC_Subscriptions_Core_Plugin::class, 'instance' ] ) ) {
+
+				 $instance = \WC_Subscriptions_Core_Plugin::instance();
+
+				 if ( is_object( $instance ) && method_exists( $instance, 'get_library_version' ) ) {
+					 return $instance->get_library_version();
+				 }
+			 }
+		}
+
+		return null;
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -1379,7 +1379,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		 *
 		 * @param bool $subscriptions_active
 		 */
-		return apply_filters( 'sv_wc_payment_gateway_is_subscriptions_active', $this->subscriptions_active );
+		return (bool) apply_filters( 'sv_wc_payment_gateway_is_subscriptions_active', $this->subscriptions_active );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -1364,13 +1364,13 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 	 *
 	 * @return bool true if the WooCommerce Subscriptions plugin is active, false if not active
 	 */
-	public function is_subscriptions_active() {
+	public function is_subscriptions_active() : bool {
 
 		if ( is_bool( $this->subscriptions_active ) ) {
 			return $this->subscriptions_active;
 		}
 
-		return $this->subscriptions_active = $this->is_plugin_active( 'woocommerce-subscriptions.php' );
+		return $this->subscriptions_active = class_exists( 'WC_Subscriptions_Core_Plugin' ) || $this->is_plugin_active( 'woocommerce-subscriptions.php' );
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -1370,8 +1370,6 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 			return $this->subscriptions_active;
 		}
 
-		$this->subscriptions_active = class_exists( 'WC_Subscriptions_Core_Plugin' ) || $this->is_plugin_active( 'woocommerce-subscriptions.php' );
-
 		/**
 		 * Filters whether WooCommerce Subscriptions is active.
 		 *
@@ -1379,7 +1377,9 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 		 *
 		 * @param bool $subscriptions_active
 		 */
-		return (bool) apply_filters( 'sv_wc_payment_gateway_is_subscriptions_active', $this->subscriptions_active );
+		$this->subscriptions_active = (bool) apply_filters( 'sv_wc_payment_gateway_is_subscriptions_active',  class_exists( 'WC_Subscriptions_Core_Plugin' ) || $this->is_plugin_active( 'woocommerce-subscriptions.php' ) );
+
+		return $this->subscriptions_active;
 	}
 
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-plugin.php
@@ -1358,7 +1358,7 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 
 
 	/**
-	 * Checks is WooCommerce Subscriptions is active
+	 * Checks is WooCommerce Subscriptions is active as a plugin or as a core library
 	 *
 	 * @since 1.0.0
 	 *
@@ -1370,7 +1370,16 @@ abstract class SV_WC_Payment_Gateway_Plugin extends SV_WC_Plugin {
 			return $this->subscriptions_active;
 		}
 
-		return $this->subscriptions_active = class_exists( 'WC_Subscriptions_Core_Plugin' ) || $this->is_plugin_active( 'woocommerce-subscriptions.php' );
+		$this->subscriptions_active = class_exists( 'WC_Subscriptions_Core_Plugin' ) || $this->is_plugin_active( 'woocommerce-subscriptions.php' );
+
+		/**
+		 * Filters whether WooCommerce Subscriptions is active.
+		 *
+		 * This future proofs the plugin for when WooCommerce Subscriptions is included as a core library or third party plugin embedding the core library.
+		 *
+		 * @param bool $subscriptions_active
+		 */
+		return apply_filters( 'sv_wc_payment_gateway_is_subscriptions_active', $this->subscriptions_active );
 	}
 
 


### PR DESCRIPTION
# Summary

WooCommerce Subscriptions might exist as a split library from https://github.com/Automattic/woocommerce-subscriptions-core -- this library includes nearly all the functionalities from WooCommerce Subscriptions. 

If a plugin or third party code uses this library, gateways or plugins that use this framework and integrate with Subscriptions won't work because this framework only checks if the Subscriptions plugin is active, not the standalone lib.

The checks in this PR have been updated to account for that possibility.