### PR TITLE
Handle backwards compatibility for old HPOS compatibility format

### DIFF
--- a/tests/unit/PluginTest.php
+++ b/tests/unit/PluginTest.php
@@ -2,6 +2,7 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_15_0\Tests\Unit;
 
+use Generator;
 use Mockery;
 use ReflectionException;
 use SkyVerge\WooCommerce\PluginFramework\v5_15_0\SV_WC_Plugin;
@@ -84,5 +85,49 @@ class PluginTest extends TestCase
 		$this->assertNull(
 			$this->invokeInaccessibleMethod($this->testObject, 'assert', false)
 		);
+	}
+
+	/**
+	 * @covers \SkyVerge\WooCommerce\PluginFramework\v5_15_0\SV_WC_Plugin::maybeHandleBackwardsCompatibleArgs()
+	 * @dataProvider providerCanMaybeHandleBackwardsCompatibleArgs
+	 * @throws ReflectionException
+	 */
+	public function testCanMaybeHandleBackwardsCompatibleArgs(array $inputArgs, array $outputArgs): void
+	{
+		$this->assertSame(
+			$outputArgs,
+			$this->invokeInaccessibleMethod($this->testObject, 'maybeHandleBackwardsCompatibleArgs', $inputArgs)
+		);
+	}
+
+	/** @see testCanMaybeHandleBackwardsCompatibleArgs */
+	public function providerCanMaybeHandleBackwardsCompatibleArgs(): Generator
+	{
+		yield 'no HPOS args' => [
+			'inputArgs' => [],
+			'outputArgs' => [],
+		];
+
+		yield 'old HPOS args, no support' => [
+			'inputArgs' => [
+				'supports_hpos' => false,
+			],
+			'outputArgs' => [
+				'supported_features' => [
+					'hpos'   => false,
+				],
+			],
+		];
+
+		yield 'old HPOS args, has support' => [
+			'inputArgs' => [
+				'supports_hpos' => true,
+			],
+			'outputArgs' => [
+				'supported_features' => [
+					'hpos'   => true,
+				],
+			],
+		];
 	}
 }

--- a/tests/unit/PluginTest.php
+++ b/tests/unit/PluginTest.php
@@ -104,28 +104,42 @@ class PluginTest extends TestCase
 	public function providerCanMaybeHandleBackwardsCompatibleArgs(): Generator
 	{
 		yield 'no HPOS args' => [
-			'inputArgs' => [],
+			'inputArgs'  => [],
 			'outputArgs' => [],
 		];
 
 		yield 'old HPOS args, no support' => [
-			'inputArgs' => [
+			'inputArgs'  => [
 				'supports_hpos' => false,
 			],
 			'outputArgs' => [
 				'supported_features' => [
-					'hpos'   => false,
+					'hpos' => false,
 				],
 			],
 		];
 
 		yield 'old HPOS args, has support' => [
-			'inputArgs' => [
+			'inputArgs'  => [
 				'supports_hpos' => true,
 			],
 			'outputArgs' => [
 				'supported_features' => [
-					'hpos'   => true,
+					'hpos' => true,
+				],
+			],
+		];
+
+		yield 'old HPOS args and new HPOS args' => [
+			'inputArgs'  => [
+				'supports_hpos'      => true,
+				'supported_features' => [
+					'hpos' => false,
+				],
+			],
+			'outputArgs' => [
+				'supported_features' => [
+					'hpos' => false,
 				],
 			],
 		];

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -189,15 +189,15 @@ abstract class SV_WC_Plugin {
 	 * @param array $args
 	 * @return array
 	 */
-	private function maybeHandleBackwardsCompatibleArgs(array $args): array
+	protected function maybeHandleBackwardsCompatibleArgs(array $args): array
 	{
 		// handle format change for HPOS declaration
 		if (
 			array_key_exists('supports_hpos', $args) &&
-			$args['supports_hpos'] === true &&
 			! isset($args['supported_features']['hpos'])
 		) {
-			$args['supported_features']['hpos'] = true;
+			$args['supported_features']['hpos'] = $args['supports_hpos'];
+			unset($args['supports_hpos']);
 		}
 
 		return $args;

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -140,7 +140,7 @@ abstract class SV_WC_Plugin {
 		$this->id      = $id;
 		$this->version = $version;
 
-		$args = wp_parse_args( $args, [
+		$args = wp_parse_args( $this->maybeHandleBackwardsCompatibleArgs($args), [
 			'text_domain'        => '',
 			'dependencies'       => [],
 			'supported_features' => [
@@ -181,6 +181,26 @@ abstract class SV_WC_Plugin {
 
 		// add the action & filter hooks
 		$this->add_hooks();
+	}
+
+	/**
+	 * Provides backward compatibility for arguments, where we can. This handles any format changes in the $args array.
+	 *
+	 * @param array $args
+	 * @return array
+	 */
+	private function maybeHandleBackwardsCompatibleArgs(array $args): array
+	{
+		// handle format change for HPOS declaration
+		if (
+			array_key_exists('supports_hpos', $args) &&
+			$args['supports_hpos'] === true &&
+			! isset($args['supported_features']['hpos'])
+		) {
+			$args['supported_features']['hpos'] = true;
+		}
+
+		return $args;
 	}
 
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -192,11 +192,15 @@ abstract class SV_WC_Plugin {
 	protected function maybeHandleBackwardsCompatibleArgs(array $args): array
 	{
 		// handle format change for HPOS declaration
-		if (
-			array_key_exists('supports_hpos', $args) &&
-			! isset($args['supported_features']['hpos'])
-		) {
-			$args['supported_features']['hpos'] = $args['supports_hpos'];
+		if (array_key_exists('supports_hpos', $args)) {
+			// make sure `supported_features` initialized
+			if (! array_key_exists('supported_features', $args)) {
+				$args['supported_features'] = [];
+			}
+
+			// Assign `supported_features.hpos` value if not already assigned
+			$args['supported_features']['hpos'] = $args['supported_features']['hpos'] ?? $args['supports_hpos'];
+
 			unset($args['supports_hpos']);
 		}
 


### PR DESCRIPTION
# Summary

This adds backwards compatibility for the old HPOS compatibility format. If the old format is detected, it's converted to the new one.

### Story: https://godaddy-corp.atlassian.net/browse/MWC-17548

## Details

_Additional details to expand on the summary, if needed_

## QA

### Setup

- Checkout [Cost of Goods v2.13.2](https://github.com/gdcorp-partners/woocommerce-cost-of-goods/releases/tag/2.13.2) and activate it

You should see a notice like this:

![image](https://github.com/user-attachments/assets/4ac6b6b1-8874-4e13-a8d3-28ac38556b03)

### Steps

1. In CoGs, update the SV Framework to use this branch. You will also have to update the namespaces.
2. In the `woocommerce-cost-of-goods.php` file, edit the `init_plugin()` method like so:
```diff
	public function init_plugin() {

		if ( ! $this->plugins_compatible() ) {
			return;
		}

+		require_once plugin_dir_path(__FILE__) . '/vendor/autoload.php';

		$this->load_framework();

		// load the main plugin class
		require_once( plugin_dir_path( __FILE__ ) . 'class-wc-cog.php' );

		// fire it up!
		wc_cog();
	}
```
4. Refresh wp-admin
    - [x] The notice is no longer appearing

![image](https://github.com/user-attachments/assets/fcf2f9f1-741c-43fe-ac26-8afdcbe27d11)

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
