### PR TITLE
Ensure that no fatal error occurs while processing a subscription renewal when the object is stored in the subscription's metadata.

### DIFF
--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -448,7 +448,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		foreach ( (array) $order_meta as $index => $meta ) {
 
 			// this accounts for different versions of the Subscriptions filter running before and after WooCommerce Subscriptions 2.5
-			if ( in_array( $index, $meta_keys ) || ( isset( $meta['meta_key'] ) && in_array( $meta['meta_key'], $meta_keys ) ) ) {
+			if ( in_array( $index, $meta_keys ) || ( is_array( $meta ) && isset( $meta['meta_key'] ) && in_array( $meta['meta_key'], $meta_keys ) ) ) {
 				unset( $order_meta[ $index ] );
 			}
 		}

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -448,7 +448,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 		foreach ( (array) $order_meta as $index => $meta ) {
 
 			// this accounts for different versions of the Subscriptions filter running before and after WooCommerce Subscriptions 2.5
-			if ( in_array( $index, $meta_keys ) || ( is_array( $meta ) && isset( $meta['meta_key'] ) && in_array( $meta['meta_key'], $meta_keys ) ) ) {
+			if ( in_array( $index, $meta_keys, true ) || ( is_array( $meta ) && isset( $meta['meta_key'] ) && in_array( $meta['meta_key'], $meta_keys, true ) ) ) {
 				unset( $order_meta[ $index ] );
 			}
 		}


### PR DESCRIPTION
# Summary
We recently received a report from a customer that a subscription renewal fails with a fatal error when HPOS is enabled. Upon investigation, we found that this was caused by another extension on the site setting a `WC_Cart` object in the subscription's metadata, leading to a fatal error being thrown from our `do_not_copy_order_meta` function.  

While storing objects in metadata is unusual, as part of defensive programming, it is better to add a check to ensure the data is valid before verifying whether a specific key exists. This PR makes a minor change to ensure that `$meta` is an array before checking if `$meta['meta_key']` is set.

Fatal error:
```
ERROR scheduled action 11656188 (subscription payment) failed to finish processing due to the following exception: Cannot use object of type WC_Cart as array in /wp-content/plugins/woocommerce-gateway-paypal-powered-by-braintree/vendor/skyverge/wc-plugin-framework/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php:450
```


## UI Changes
N/A

## QA
1. Purchase a subscription product.  
2. Add any object to the subscription's metadata.  
3. Go to **Edit Subscription**, select **"Process Renewal"** from the order actions, and submit.  
4. Verify that the subscription renewal is processed successfully without a fatal error.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
