### PR TITLE
Add a `PageHelper` class to check for current admin page

### DIFF
--- a/tests/unit/Helpers/ArrayHelperTest.php
+++ b/tests/unit/Helpers/ArrayHelperTest.php
@@ -251,6 +251,92 @@ final class ArrayHelperTest extends TestCase
 		];
 	}
 
+	/**
+	 * Tests that the helper will return default with key not found.
+	 *
+	 * @covers ::get()
+	 */
+	public function testCanReturnDefaultWhenGetArrayValueByKeyNotFound() : void
+	{
+		$this->assertNull(ArrayHelper::get([], 'key'), 'ArrayHelper::get() does not return null by default as expected');
+		$this->assertEquals('myDefault', ArrayHelper::get([], 'key', 'myDefault'));
+		$this->assertNotEquals('myDefault', ArrayHelper::get(['key' => 'value'], 'key', 'myDefault'));
+	}
+
+	/**
+	 * Tests that can retrieve array value by key without PHP error/warning.
+	 *
+	 * @covers ::get()
+	 * @dataProvider providerCanGetArrayValueByKey
+	 *
+	 * @param mixed $array
+	 * @param int|string $key
+	 * @param mixed $expected
+	 * @return void
+	 */
+	public function testCanGetArrayValueByKey($array, $key, $expected) : void
+	{
+		$this->assertSame($expected, ArrayHelper::get($array, $key));
+	}
+
+	/** @see testCanGetArrayValueByKey() */
+	public function providerCanGetArrayValueByKey() : Generator
+	{
+		yield 'Existing string key in a key/value array' => [
+			'array'    => ['key' => 'found'],
+			'key'      => 'key',
+			'expected' => 'found',
+		];
+
+		yield 'Nonexistent string key in a key/value array' => [
+			'array'    => ['key' => 'notfound'],
+			'key'      => 'value',
+			'expected' => null,
+		];
+
+		yield 'Existing nested key with dot notation' => [
+			'array'    => ['key' => ['nested' => ['deeply' => 'found']]],
+			'key'      => 'key.nested.deeply',
+			'expected' => 'found',
+		];
+
+		yield 'Nonexistent nested key with dot notation' => [
+			'array'    => ['key' => ['nested' => ['deeply' => 'notfound']]],
+			'key'      => 'key.nested.more.deeply',
+			'expected' => null,
+		];
+
+		yield 'Existing dot-notated key as key is returned without iteration' => [
+			'array'    => ['dot.notated.key' => 'found'],
+			'key'      => 'dot.notated.key',
+			'expected' => 'found',
+		];
+
+		yield 'Existing numeric index' => [
+			'array'    => ['foo', 'bar', 'baz'],
+			'key'      => 1,
+			'expected' => 'bar',
+		];
+
+		yield 'Nonexistent numeric index' => [
+			'array'    => ['foo', 'bar', 'baz'],
+			'key'      => 3,
+			'expected' => null,
+		];
+
+		yield 'Existing numeric string index' => [
+			'array'    => ['foo', 'bar', 'baz'],
+			'key'      => '2',
+			'expected' => 'baz',
+		];
+
+		yield 'Nonexistent numeric string index' => [
+			'array'    => ['foo', 'bar', 'baz'],
+			'key'      => '3',
+			'expected' => null,
+		];
+	}
+
 	protected function getArrayAccessObject(): ArrayAccess
 	{
 		return new class implements ArrayAccess

--- a/tests/unit/Helpers/PageHelperTest.php
+++ b/tests/unit/Helpers/PageHelperTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SkyVerge\WooCommerce\PluginFramework\v5_15_4\Tests\unit\Helpers;
+namespace SkyVerge\WooCommerce\PluginFramework\v5_15_4\Tests\Unit\Helpers;
 
 use Generator;
 use Mockery;

--- a/tests/unit/Helpers/PageHelperTest.php
+++ b/tests/unit/Helpers/PageHelperTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_15_4\Tests\unit\Helpers;
+
+use Generator;
+use Mockery;
+use SkyVerge\WooCommerce\PluginFramework\v5_15_4\Helpers\PageHelper;
+use SkyVerge\WooCommerce\PluginFramework\v5_15_4\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \SkyVerge\WooCommerce\PluginFramework\v5_15_4\Helpers\PageHelper
+ */
+final class PageHelperTest extends TestCase
+{
+	/**
+	 * @covers ::isWooCommerceAnalyticsPage()
+	 * @dataProvider providerCanDetermineIsWooCommerceAnalyticsPage
+	 * @throws \ReflectionException
+	 */
+	public function testCanDetermineIsWooCommerceAnalyticsPage($pageData, bool $expected) : void
+	{
+		$pageController = Mockery::mock(\Automattic\WooCommerce\Admin\PageController::class);
+		$pageController->expects('get_current_page')
+			->once()
+			->andReturn($pageData);
+
+		$this->mockStaticMethod(PageHelper::class, 'getWooCommercePageController')
+			->once()
+			->andReturn($pageController);
+
+		$this->assertSame($expected, PageHelper::isWooCommerceAnalyticsPage());
+	}
+
+	/** @see testCanDetermineIsWooCommerceAnalyticsPage */
+	public function providerCanDetermineIsWooCommerceAnalyticsPage() : Generator
+	{
+		yield 'no page data' => [
+			'pageData' => false,
+			'expected' => false,
+		];
+
+		yield 'woocommerce home' => [
+			'pageData' => [
+				'id' => 'woocommerce-home',
+				'parent' => 'woocommerce',
+			],
+			'expected' => false,
+		];
+
+		yield 'orders page' => [
+			'pageData' => [
+				'id' => 'woocommerce-custom-orders',
+			],
+			'expected' => false,
+		];
+
+		yield 'analytics overview' => [
+			'pageData' => [
+				'id' => 'woocommerce-analytics',
+				'parent' => null,
+			],
+			'expected' => true,
+		];
+
+		yield 'analytics revenue' => [
+			'pageData' => [
+				'id' => 'woocommerce-analytics-revenue',
+				'parent' => 'woocommerce-analytics',
+			],
+			'expected' => true,
+		];
+
+		yield 'analytics products' => [
+			'pageData' => [
+				'id' => 'woocommerce-analytics-products',
+				'parent' => 'woocommerce-analytics',
+			],
+			'expected' => true,
+		];
+	}
+}

--- a/woocommerce/Helpers/ArrayHelper.php
+++ b/woocommerce/Helpers/ArrayHelper.php
@@ -123,4 +123,33 @@ class ArrayHelper
 
 		return array_key_exists($key, self::wrap($array));
 	}
+
+	/**
+	 * Gets an array value from a dot notated key.
+	 *
+	 * @param mixed $array
+	 * @param int|string $key
+	 * @param mixed $default
+	 * @return mixed
+	 */
+	public static function get($array, $key, $default = null)
+	{
+		if (! self::accessible($array)) {
+			return $default;
+		}
+
+		if (self::exists($array, $key)) {
+			return $array[$key];
+		}
+
+		foreach (explode('.', (string) $key) as $segment) {
+			if (! self::exists($array, $segment)) {
+				return $default;
+			}
+
+			$array = $array[$segment];
+		}
+
+		return $array;
+	}
 }

--- a/woocommerce/Helpers/PageHelper.php
+++ b/woocommerce/Helpers/PageHelper.php
@@ -39,8 +39,8 @@ class PageHelper
 
 		$pageData = $controller->get_current_page();
 
-		return ($pageData['id'] ?? '') === 'woocommerce-analytics' ||
-			($pageData['parent'] ?? '') === 'woocommerce-analytics';
+		return ArrayHelper::get($pageData, 'id') === 'woocommerce-analytics' ||
+			ArrayHelper::get($pageData, 'parent') === 'woocommerce-analytics';
 	}
 
 	/**

--- a/woocommerce/Helpers/PageHelper.php
+++ b/woocommerce/Helpers/PageHelper.php
@@ -33,11 +33,11 @@ class PageHelper
 	 */
 	public static function isWooCommerceAnalyticsPage() : bool
 	{
-		if (! class_exists(\Automattic\WooCommerce\Admin\PageController::class)) {
+		if (! $controller = static::getWooCommercePageController()) {
 			return false;
 		}
 
-		$pageData = static::getWooCommercePageController()->get_current_page();
+		$pageData = $controller->get_current_page();
 
 		return ($pageData['id'] ?? '') === 'woocommerce-analytics' ||
 			($pageData['parent'] ?? '') === 'woocommerce-analytics';
@@ -46,8 +46,12 @@ class PageHelper
 	/**
 	 * @codeCoverageIgnore
 	 */
-	protected static function getWooCommercePageController() : \Automattic\WooCommerce\Admin\PageController
+	protected static function getWooCommercePageController() : ?\Automattic\WooCommerce\Admin\PageController
 	{
+		if (! class_exists(\Automattic\WooCommerce\Admin\PageController::class)) {
+			return null;
+		}
+
 		return \Automattic\WooCommerce\Admin\PageController::get_instance();
 	}
 }

--- a/woocommerce/Helpers/PageHelper.php
+++ b/woocommerce/Helpers/PageHelper.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * WooCommerce Plugin Framework
+ *
+ * This source file is subject to the GNU General Public License v3.0
+ * that is bundled with this package in the file license.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@skyverge.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade the plugin to newer
+ * versions in the future. If you wish to customize the plugin for your
+ * needs please refer to http://www.skyverge.com
+ *
+ * @package   SkyVerge/WooCommerce/Plugin/Classes
+ * @author    SkyVerge
+ * @copyright Copyright (c) 2013-2025, SkyVerge, Inc.
+ * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
+ */
+
+namespace SkyVerge\WooCommerce\PluginFramework\v5_15_4\Helpers;
+
+class PageHelper
+{
+	/**
+	 * Determines whether the current page is the WooCommerce "Analytics" page.
+	 *
+	 * @since 5.15.4
+	 */
+	public static function isWooCommerceAnalyticsPage() : bool
+	{
+		if (! class_exists(\Automattic\WooCommerce\Admin\PageController::class)) {
+			return false;
+		}
+
+		$pageData = \Automattic\WooCommerce\Admin\PageController::get_instance()->get_current_page();
+
+		return ($pageData['id'] ?? '') === 'woocommerce-analytics' ||
+			($pageData['parent'] ?? '') === 'woocommerce-analytics';
+	}
+}

--- a/woocommerce/Helpers/PageHelper.php
+++ b/woocommerce/Helpers/PageHelper.php
@@ -37,9 +37,17 @@ class PageHelper
 			return false;
 		}
 
-		$pageData = \Automattic\WooCommerce\Admin\PageController::get_instance()->get_current_page();
+		$pageData = static::getWooCommercePageController()->get_current_page();
 
 		return ($pageData['id'] ?? '') === 'woocommerce-analytics' ||
 			($pageData['parent'] ?? '') === 'woocommerce-analytics';
+	}
+
+	/**
+	 * @codeCoverageIgnore
+	 */
+	protected static function getWooCommercePageController() : \Automattic\WooCommerce\Admin\PageController
+	{
+		return \Automattic\WooCommerce\Admin\PageController::get_instance();
 	}
 }

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,8 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
-2024.nn.nn - version 5.15.4
+2025.nn.nn - version 5.15.4
+* New: Added PageHelper class to assist in determining page contexts.
+* New: Add a helper method to get WooCommerce object meta values.
 
 2025.01.24 - version 5.15.3
 * Fix - Add Merchant ID to Google Pay, distinguishing it from Gateway merchant ID


### PR DESCRIPTION
# Summary

This adds a `PageHelper` class with a handy method to check if we're on the WooCommerce analytics page.

### Release: https://github.com/godaddy-wordpress/wc-plugin-framework/pull/734

## QA

- [x] QA steps in https://github.com/gdcorp-partners/woocommerce-cost-of-goods/pull/102 pass

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
