### PR TITLE
Fix undefined array key errors

### DIFF
--- a/woocommerce/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php
+++ b/woocommerce/payment-gateway/Blocks/Gateway_Checkout_Block_Integration.php
@@ -563,8 +563,8 @@ abstract class Gateway_Checkout_Block_Integration extends AbstractPaymentMethodT
 		 * Convert the tokenization flag to the expected key-value pair:
 		 * @see SV_WC_Payment_Gateway_Payment_Tokens_Handler::should_tokenize()
 		 */
-		if ( $should_tokenize = $payment_context->payment_data['wc-' . $this->gateway->get_id() . '-new-payment-method'] ) {
-			$additional_payment_data[ 'wc-' . $this->gateway->get_id_dasherized() . '-tokenize-payment-method' ] = $should_tokenize;
+		if ($should_tokenize = ($payment_context->payment_data['wc-' . $this->gateway->get_id() . '-new-payment-method'] ?? null)) {
+			$additional_payment_data['wc-' . $this->gateway->get_id_dasherized() . '-tokenize-payment-method'] = $should_tokenize;
 		}
 
 		/**
@@ -593,7 +593,7 @@ abstract class Gateway_Checkout_Block_Integration extends AbstractPaymentMethodT
 	 */
 	protected function get_payment_token_for_context( PaymentContext $payment_context ): ?SV_WC_Payment_Gateway_Payment_Token {
 
-		$core_token_id = $payment_context->payment_data['token'] ?: null;
+		$core_token_id = $payment_context->payment_data['token'] ?? null;
 
 		if ( ! $core_token_id || $payment_context->payment_method !== $this->gateway->get_id() ) {
 			return null;


### PR DESCRIPTION
# Summary

This fixes some undefined array key errors that CyberSource + block checkout was seeing. Ref: https://github.com/gdcorp-partners/woocommerce-gateway-cybersource/pull/158

## QA

- [ ] Code review

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
