### PR TITLE
Add additional helper methods to the trait `HasEmailPreviewValuesTrait`

### DIFF
--- a/woocommerce/Emails/Traits/HasEmailPreviewValuesTrait.php
+++ b/woocommerce/Emails/Traits/HasEmailPreviewValuesTrait.php
@@ -46,7 +46,7 @@ trait HasEmailPreviewValuesTrait
 	protected function getDummyProduct() : WC_Product
 	{
 		if (class_exists(EmailPreview::class) && method_exists(EmailPreview::class, 'get_dummy_product_when_not_set')) {
-			return EmailPreview::instance()->get_dummy_product_when_not_set($this->get_product());
+			return EmailPreview::instance()->get_dummy_product_when_not_set(null);
 		} else {
 			// we should really never end up here!
 			return new WC_Product();

--- a/woocommerce/Emails/Traits/HasEmailPreviewValuesTrait.php
+++ b/woocommerce/Emails/Traits/HasEmailPreviewValuesTrait.php
@@ -21,6 +21,7 @@ trait HasEmailPreviewValuesTrait
 	/**
 	 * Gets a random, real product from the site.
 	 *
+	 * For use in rendering examples for email templates.
 	 * @return WC_Product|null
 	 */
 	protected function getRandomProduct() : ?WC_Product
@@ -41,6 +42,7 @@ trait HasEmailPreviewValuesTrait
 	/**
 	 * Gets a dummy (fake) product.
 	 *
+	 * For use in rendering examples for email templates.
 	 * @return WC_Product
 	 */
 	protected function getDummyProduct() : WC_Product

--- a/woocommerce/Emails/Traits/HasEmailPreviewValuesTrait.php
+++ b/woocommerce/Emails/Traits/HasEmailPreviewValuesTrait.php
@@ -2,6 +2,9 @@
 
 namespace SkyVerge\WooCommerce\PluginFramework\v5_15_6\Emails\Traits;
 
+use Automattic\WooCommerce\Internal\Admin\EmailPreview\EmailPreview;
+use WC_Product;
+
 /**
  * Adds improved support for the experimental "Email Improvements" feature, by populating any missing properties
  * with default/placeholder values.
@@ -14,4 +17,39 @@ trait HasEmailPreviewValuesTrait
 	 * Sets "Preview" values on the email object.
 	 */
 	abstract public function setPreviewValues() : void;
+
+	/**
+	 * Gets a random, real product from the site.
+	 *
+	 * @return WC_Product|null
+	 */
+	protected function getRandomProduct() : ?WC_Product
+	{
+		$products = array_values(wc_get_products([
+			'post_type'      => 'product',
+			'posts_per_page' => 1,
+			'orderby'        => 'rand',
+		]));
+
+		if (isset($products[0]) && $products[0] instanceof WC_Product) {
+			return $products[0];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Gets a dummy (fake) product.
+	 *
+	 * @return WC_Product
+	 */
+	protected function getDummyProduct() : WC_Product
+	{
+		if (class_exists(EmailPreview::class) && method_exists(EmailPreview::class, 'get_dummy_product_when_not_set')) {
+			return EmailPreview::instance()->get_dummy_product_when_not_set($this->get_product());
+		} else {
+			// we should really never end up here!
+			return new WC_Product();
+		}
+	}
 }

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,7 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
 2025.nn.nn - version 5.15.6
+* New: Added additional helper methods to the trait `HasEmailPreviewValuesTrait`
 
 2025.03.05 - version 5.15.5
 * New: Add a trait to assist in compatibility with new WooCommerce email preview feature

--- a/woocommerce/changelog.txt
+++ b/woocommerce/changelog.txt
@@ -1,6 +1,6 @@
 *** SkyVerge WooCommerce Plugin Framework Changelog ***
 
-2025.nn.nn - version 5.15.6
+2025.nn.nn - version 5.15.6-dev.1
 * New: Added additional helper methods to the trait `HasEmailPreviewValuesTrait`
 
 2025.03.05 - version 5.15.5


### PR DESCRIPTION
# Summary

This adds some additional helper methods to the `HasEmailPreviewValuesTrait` for retrieving dummy/random objects to use in previews.

## QA

- [ ] Code review
- [ ] This branch is used in https://github.com/gdcorp-partners/woocommerce-product-reviews-pro/pull/81 and QA can be done there

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
