### PR TITLE
Fixes for loading translations too early

### DIFF
--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -203,6 +203,12 @@ class SV_WC_Hook_Deprecator {
 		SV_WC_Helper::trigger_error( $message );
 	}
 
+
+	/**
+	 * Gets the plugin name.
+	 *
+	 * @return string
+	 */
 	protected function getPluginName() : string
 	{
 		if (isset($this->plugin)) {

--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -55,8 +55,8 @@ class SV_WC_Hook_Deprecator {
 	 *
 	 * @since 5.15.7 The `$plugin_name` parameter has been renamed to `$plugin` and now expects an `SV_WC_Plugin`
 	 *               object. This change is to avoid loading translations too early. Support for `$plugin` as
-	 *               plugin name remains for back-compat though it will likely generate `_load_textdomain_just_in_time`
-	 *               notices for the current extension.
+	 *               plugin name remains for back-compat though it will likely result in `_load_textdomain_just_in_time`
+	 *               notices being logged for the current extension.
 	 */
 	public function __construct($plugin, $hooks)
 	{

--- a/woocommerce/class-sv-wc-hook-deprecator.php
+++ b/woocommerce/class-sv-wc-hook-deprecator.php
@@ -53,8 +53,10 @@ class SV_WC_Hook_Deprecator {
 	 * @param string|SV_WC_Plugin $plugin Plugin instance or string name of plugin (latter is deprecated)
 	 * @param array $hooks
 	 *
-	 * @since 5.15.7 First parameter as `$plugin_name` has been deprecated due to the need to instantiate this class
-	 *               before translations may have been loaded.
+	 * @since 5.15.7 The `$plugin_name` parameter has been renamed to `$plugin` and now expects an `SV_WC_Plugin`
+	 *               object. This change is to avoid loading translations too early. Support for `$plugin` as
+	 *               plugin name remains for back-compat though it will likely generate `_load_textdomain_just_in_time`
+	 *               notices for the current extension.
 	 */
 	public function __construct($plugin, $hooks)
 	{

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -262,6 +262,7 @@ abstract class SV_WC_Plugin {
 	 * Plugins can override this with their own handler.
 	 *
 	 * @since 5.2.0
+	 * @since 5.15.7 The full `SV_WC_Plugin` instance is now used to instantiate `SV_WC_Hook_Deprecator`.
 	 */
 	protected function init_hook_deprecator() {
 

--- a/woocommerce/class-sv-wc-plugin.php
+++ b/woocommerce/class-sv-wc-plugin.php
@@ -265,7 +265,7 @@ abstract class SV_WC_Plugin {
 	 */
 	protected function init_hook_deprecator() {
 
-		$this->hook_deprecator = new SV_WC_Hook_Deprecator( $this->get_plugin_name(), array_merge( $this->get_framework_deprecated_hooks(), $this->get_deprecated_hooks() ) );
+		$this->hook_deprecator = new SV_WC_Hook_Deprecator( $this, array_merge( $this->get_framework_deprecated_hooks(), $this->get_deprecated_hooks() ) );
 	}
 
 


### PR DESCRIPTION
# Summary

Release: #755 

This is a partial fix (not guaranteed to be 100% complete) to address errors like this:

> Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the woocommerce-memberships domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. (This message was added in version 6.7.0.)

### Release: #755

## Details

- `SV_WC_Hook_Deprecator` has been updated to accept the entire plugin instance as a parameter instead of just the plugin name. That way we can call `get_plugin_name()` when actually used instead of inside the constructor.

## QA

- [x] QA steps in https://github.com/gdcorp-partners/woocommerce-memberships/pull/1240 pass

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
