### PR TITLE
Run 'clean' before build

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Bump package.json version
         run: npm version --no-git-tag-version --allow-same-version "${NEW_VERSION}"
 
+        # This is required because sometimes the `build` script just won't build assets unless `dist/` is cleaned first. Makes no sense, I know!
+      - name: Clean dist directory
+        run: npm run clean
+
       - name: Build assets
         run: npm run build
 


### PR DESCRIPTION
# Summary

This update sthe workflow to run `npm run clean` before building. It seems occasionally when running `npm run build` the coffee assets aren't being compiled. This can be seen by looking at the commit column -- notice how some weren't changed!

![Screenshot 2025-04-30 100543](https://github.com/user-attachments/assets/268be396-ad22-4b08-b2ae-aebf5fbf379d)

After local testing I was able to reproduce those files not changing. They only finally changed by running `npm run clean` prior to building.

## QA

1. Run the "prep release" workflow from this branch. -- workflow run https://github.com/godaddy-wordpress/wc-plugin-framework/actions/runs/14751125116/job/41408663542
    - [x] Resulting PR contains all modified `dist/*` js files.

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
