### PR TITLE
Delay usage of get_plugin_name() in payment gateway privacy class to after init

### DIFF
--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-privacy.php
@@ -53,14 +53,10 @@ class SV_WC_Payment_Gateway_Privacy extends \WC_Abstract_Privacy {
 
 		$this->plugin = $plugin;
 
-		parent::__construct( $plugin->get_plugin_name() );
+		parent::__construct();
 
 		// add the action & filter hooks
 		$this->add_hooks();
-
-		// add the token exporters & erasers
-		$this->add_exporter( "wc-{$plugin->get_id_dasherized()}-customer-tokens", __( "{$plugin->get_plugin_name()} Payment Tokens", 'woocommerce-plugin-framework' ), array( $this, 'customer_tokens_exporter' ) );
-		$this->add_eraser(   "wc-{$plugin->get_id_dasherized()}-customer-tokens", __( "{$plugin->get_plugin_name()} Payment Tokens", 'woocommerce-plugin-framework' ), array( $this, 'customer_tokens_eraser' ) );
 	}
 
 
@@ -70,6 +66,9 @@ class SV_WC_Payment_Gateway_Privacy extends \WC_Abstract_Privacy {
 	 * @since 5.1.4
 	 */
 	protected function add_hooks() {
+
+		// initializes data exporters and erasers
+		add_action('init', [$this, 'registerExportersAndErasers']);
 
 		// add the gateway data to customer data exports
 		add_filter( 'woocommerce_privacy_export_customer_personal_data', array( $this, 'add_export_customer_data' ), 10, 2 );
@@ -82,6 +81,20 @@ class SV_WC_Payment_Gateway_Privacy extends \WC_Abstract_Privacy {
 
 		// removes the gateway data during an order data erasure
 		add_action( 'woocommerce_privacy_remove_order_personal_data', array( $this, 'remove_order_personal_data' ) );
+	}
+
+	/**
+	 * Initial registration of privacy erasers and exporters.
+	 *
+	 *  Due to the use of translation functions, this should run only on/after init.
+	 */
+	public function registerExportersAndErasers()
+	{
+		$this->name = $this->plugin->get_plugin_name();
+
+		// add the token exporters & erasers
+		$this->add_exporter("wc-{$this->plugin->get_id_dasherized()}-customer-tokens", __("{$this->plugin->get_plugin_name()} Payment Tokens", 'woocommerce-plugin-framework'), [$this, 'customer_tokens_exporter']);
+		$this->add_eraser("wc-{$this->plugin->get_id_dasherized()}-customer-tokens", __("{$this->plugin->get_plugin_name()} Payment Tokens", 'woocommerce-plugin-framework'), [$this, 'customer_tokens_eraser']);
 	}
 
 


### PR DESCRIPTION
Release: https://github.com/godaddy-wordpress/wc-plugin-framework/pull/763

# Summary

This is another change to fix "translations loaded too early". This impacts plugins that use the privacy class. It delays some of the logic until after `init`. I followed WooCommerce core's lead a bit here: https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-privacy.php#L32-L36

## Details



## QA

1. Update a payment gateway plugin to use this branch -- e.g. https://github.com/gdcorp-partners/woocommerce-gateway-authorize-net-cim/pull/113
2. Go to Tools > Export Personal Data and submit an export for someone who has placed an order with that gateway.
3. Download the file.
4. Open the `index.html` file
    - [x] You see "Authorize.Net Credit Card Payment Tokens" at the top
5. Click it
    - [x] Data is present

![image](https://github.com/user-attachments/assets/7e471cda-b4b1-42d3-b3dc-806148b92eef)

![image](https://github.com/user-attachments/assets/0d68fdcb-1239-4ee7-9976-365982ecf724)


## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
