### PR TITLE
fix/767: remove common JS modules from dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,12 @@
     "time-grunt": "^2.0",
     "underscore": "^1.13",
     "underscore.string": "^3.3"
+  },
+  "targets": {
+    "default": {
+      "context": "browser",
+      "outputFormat": "global",
+      "isLibrary": false
+    }
   }
 }


### PR DESCRIPTION
# Summary

Closes #767 

Adds Parcel config to output browser compatible JS.

### Steps

Steps should be in a step => success? format, like below:

1. Run `npm ci && npm run build`
2. Visit the order edit screen and observe the error (see issue) isn't visible.

- [x] Code review

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
