### PR TITLE
Only call wcs_get_subscriptions_for_order() if order ID is > 0

### DIFF
--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -260,7 +260,9 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 				$order->payment->recurring = true;
 
-				$subscriptions = wcs_get_subscriptions_for_order( $order );
+				// an order ID might be 0 if it's a mock order we use when adding a payment method
+				// passing in an order with an ID of 0 to `wcs_get_subscriptions_for_order()` can cause very unexpected results
+				$subscriptions = $order->get_id() > 0 ? wcs_get_subscriptions_for_order( $order ) : [];
 
 				if ( ! empty( $subscriptions ) ) {
 
@@ -278,7 +280,9 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 				$order->payment->recurring = true;
 
-				$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
+				// an order ID might be 0 if it's a mock order we use when adding a payment method
+				// passing in an order with an ID of 0 to `wcs_get_subscriptions_for_order()` can cause very unexpected results
+				$subscriptions = $order->get_id() > 0 ? wcs_get_subscriptions_for_order( $order ) : [];
 
 				if ( ! empty( $subscriptions ) ) {
 

--- a/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
+++ b/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php
@@ -282,7 +282,7 @@ class SV_WC_Payment_Gateway_Integration_Subscriptions extends SV_WC_Payment_Gate
 
 				// an order ID might be 0 if it's a mock order we use when adding a payment method
 				// passing in an order with an ID of 0 to `wcs_get_subscriptions_for_order()` can cause very unexpected results
-				$subscriptions = $order->get_id() > 0 ? wcs_get_subscriptions_for_order( $order ) : [];
+				$subscriptions = $order->get_id() > 0 ? wcs_get_subscriptions_for_renewal_order( $order ) : [];
 
 				if ( ! empty( $subscriptions ) ) {
 


### PR DESCRIPTION
# Summary

This updates our code to only call `wcs_get_subscriptions_for_order()` if we have an order with a real ID.

### Story: [MWC-18156](https://godaddy-corp.atlassian.net/browse/MWC-18156)
### Release: #771 (release PR)

## QA

### Old FW version

I don't actually know how to reproduce the original issue, so we're just going to confirm behaviour matching with what we know.

1. Deactivate all SkyVerge plugins except Authorize[dot]net. This just ensures we're definitely loading Anet's version of the framework.
2. Activate Subscriptions.
3. Activate Authorize[dot]net (use `master` branch) and edit this file: `woocommerce-gateway-authorize-net-cim/vendor/skyverge/wc-plugin-framework/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php`
4. Find the `add_subscriptions_details_to_order()` function definition (changed in this PR) and add logging right after we define `$subscriptions`.
```diff
	public function add_subscriptions_details_to_order( $order, $gateway ) {

		if ( isset( $order->payment ) ) {

			// defaults
			$order->payment->subscriptions = [];
			$order->payment->recurring     = ! empty( $order->payment->recurring ) ?: false;

			// if the order contains a subscription (but is not a renewal)
			if ( wcs_order_contains_subscription( $order ) ) {

				$order->payment->recurring = true;

				$subscriptions = wcs_get_subscriptions_for_order( $order );
+				error_log(sprintf('Order ID: %d; Number Subscriptions: %d', $order->get_id(), count($subscriptions)));

				if ( ! empty( $subscriptions ) ) {

					foreach ( $subscriptions as $subscription ) {

						if ( $subscription instanceof \WC_Subscription ) {

							$order->payment->subscriptions[] = $this->add_subscription_details_to_order( $subscription, false );
						}
					}
				}

			// order is for a subscription renewal
			} elseif ( wcs_order_contains_renewal( $order ) ) {

				$order->payment->recurring = true;

				$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
+				error_log(sprintf('Order ID: %d; Number Subscriptions: %d', $order->get_id(), count($subscriptions)));

				if ( ! empty( $subscriptions ) ) {

					foreach ( $subscriptions as $subscription ) {

						if ( $subscription instanceof \WC_Subscription ) {

							$order->payment->subscriptions[] = $this->add_subscription_details_to_order( $subscription, true );
						}
					}
				}
			}
		}

		return $order;
	}
```
5. Order a subscription product while tailing your logs. Note the results. (I get one subscription like this: `Order ID: 1114; Number Subscriptions: 1`)

### New FW version

1. Checkout this branch of anet: https://github.com/gdcorp-partners/woocommerce-gateway-authorize-net-cim/pull/117
2. Run `composer install`
3. Edit that same file again `woocommerce-gateway-authorize-net-cim/vendor/skyverge/wc-plugin-framework/woocommerce/payment-gateway/integrations/class-sv-wc-payment-gateway-integration-subscriptions.php`
4. Put the same `error_log(sprintf('Order ID: %d; Number Subscriptions: %d', $order->get_id(), count($subscriptions)));` in place
5. Order a subscription product while tailing your logs.
    - [x] Results match old FW version

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
