### PR TITLE
Use the release.md PR template when creating release PRs with the workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -21,4 +21,5 @@ _List of related issues, pull requests, external pages, etc_
 
 ## Before merge
 
+- [ ] I have updated `woocommerce/changelog.txt`
 - [ ] I have confirmed the final story is merged

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Create pull request
         run: |
-          gh pr create -B "${BASE_BRANCH}" -H release/"${NEW_VERSION}" --title "Release v${NEW_VERSION}" --body "Release v${NEW_VERSION}" --draft
+          gh pr create -B "${BASE_BRANCH}" -H release/"${NEW_VERSION}" --title "Release v${NEW_VERSION}" --template "release.md" --draft
         env:
           BASE_BRANCH: ${{ github.ref_name }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Summary

Updates the [Prepare Release](.github/workflows/prep-release.yml] workflow to specify the release.md PR template when creating release PRs.

## Details

Also adds a checkbox to the "Before merge" section as a reminder to update the `woocommerce/changelog.txt` file

## QA
### Steps

1. Run the [Prepare Release](https://github.com/godaddy-wordpress/wc-plugin-framework/actions/workflows/prep-release.yml) workflow on this branch with any version number
    - [ ] A PR was created using the `release.md` pull request template.