### PR TITLE
Explicitly mark parameters as nullable

### DIFF
--- a/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Hosted_Payment_Handler.php
@@ -194,7 +194,7 @@ abstract class Abstract_Hosted_Payment_Handler extends Abstract_Payment_Handler 
 	 * @param \WC_Order|null $order order object, if any
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response API response object, if any
 	 */
-	protected function do_transaction_response_complete( \WC_Order $order = null, FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	protected function do_transaction_response_complete( ?\WC_Order $order = null, ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		$this->do_transaction_request_response( $response, $this->get_gateway()->get_return_url( $order ) );
 	}
@@ -210,7 +210,7 @@ abstract class Abstract_Hosted_Payment_Handler extends Abstract_Payment_Handler 
 	 * @param string $user_message user-facing message
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response API response object, if any
 	 */
-	protected function do_transaction_response_failed( \WC_Order $order = null, $message = '', $user_message = '', FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	protected function do_transaction_response_failed( ?\WC_Order $order = null, $message = '', $user_message = '', ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		$this->get_gateway()->add_debug_message( $message, 'error' );
 
@@ -235,7 +235,7 @@ abstract class Abstract_Hosted_Payment_Handler extends Abstract_Payment_Handler 
 	 * @param string $message error message, for logging
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response API response object, if any
 	 */
-	protected function do_transaction_response_invalid( \WC_Order $order = null, $message = '', FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	protected function do_transaction_response_invalid( ?\WC_Order $order = null, $message = '', ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		$this->get_gateway()->add_debug_message( $message, 'error' );
 
@@ -264,7 +264,7 @@ abstract class Abstract_Hosted_Payment_Handler extends Abstract_Payment_Handler 
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response
 	 * @param string $url
 	 */
-	protected function do_transaction_request_response( FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null, $url = '' ) {
+	protected function do_transaction_request_response( ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null, $url = '' ) {
 
 		// if this is an IPN handler
 		if ( $this->is_ipn() ) {

--- a/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
+++ b/woocommerce/payment-gateway/Handlers/Abstract_Payment_Handler.php
@@ -288,7 +288,7 @@ abstract class Abstract_Payment_Handler {
 	 * @param string $message failure message
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response response object
 	 */
-	protected function process_order_transaction_failed( \WC_Order $order, $message = '', FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	protected function process_order_transaction_failed( \WC_Order $order, $message = '', ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		$this->mark_order_as_failed( $order, $message, $response );
 	}
@@ -305,7 +305,7 @@ abstract class Abstract_Payment_Handler {
 	 * @param \WC_Order $order order object
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Customer_Response|FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response API response object
 	 */
-	public function mark_order_as_paid( \WC_Order $order, FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	public function mark_order_as_paid( \WC_Order $order, ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		$this->get_gateway()->add_transaction_data( $order, $response );
 
@@ -343,7 +343,7 @@ abstract class Abstract_Payment_Handler {
 	 * @param string $message message for the order note
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response API response object
 	 */
-	public function mark_order_as_approved( \WC_Order $order, $message = '', FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	public function mark_order_as_approved( \WC_Order $order, $message = '', ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		$order->add_order_note( $message );
 	}
@@ -360,7 +360,7 @@ abstract class Abstract_Payment_Handler {
 	 * @param string $message order note message
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response
 	 */
-	public function mark_order_as_held( \WC_Order $order, $message = '', FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	public function mark_order_as_held( \WC_Order $order, $message = '', ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		/* translators: Example: "Authorize.Net Transaction Held for Review". Placeholder: %s - Payment gateway title */
 		$order_note = sprintf( __( '%s Transaction Held for Review', 'woocommerce-plugin-framework' ), $this->get_gateway()->get_method_title() );
@@ -390,7 +390,7 @@ abstract class Abstract_Payment_Handler {
 	 *
 	 * @return string
 	 */
-	public function get_held_order_status( \WC_Order $order, $response = null ) {
+	public function get_held_order_status( \WC_Order $order, ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		/**
 		 * Held Order Status Filter.
@@ -431,7 +431,7 @@ abstract class Abstract_Payment_Handler {
 	 * @param string $message order note message
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response
 	 */
-	public function mark_order_as_failed( \WC_Order $order, $message = '', FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	public function mark_order_as_failed( \WC_Order $order, $message = '', ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		/* translators: Placeholders: %s - payment gateway title */
 		$order_note = sprintf( esc_html__( '%s Payment Failed', 'woocommerce-plugin-framework' ), $this->get_gateway()->get_method_title() );
@@ -458,7 +458,7 @@ abstract class Abstract_Payment_Handler {
 	 * @param string $message order note message
 	 * @param FrameworkBase\SV_WC_Payment_Gateway_API_Response|null $response
 	 */
-	public function mark_order_as_cancelled( \WC_Order $order, $message, FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
+	public function mark_order_as_cancelled( \WC_Order $order, $message, ?FrameworkBase\SV_WC_Payment_Gateway_API_Response $response = null ) {
 
 		/* translators: Placeholders: %s - payment gateway title */
 		$order_note = sprintf( __( '%s Transaction Cancelled', 'woocommerce-plugin-framework' ), $this->get_gateway()->get_method_title() );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-direct.php
@@ -977,7 +977,7 @@ abstract class SV_WC_Payment_Gateway_Direct extends SV_WC_Payment_Gateway {
 	 * @return array result with success/error message and request status (success/failure)
 	 * @throws SV_WC_Plugin_Exception
 	 */
-	protected function do_add_payment_method_transaction( \WC_Order $order, SV_WC_Payment_Gateway_API_Create_Payment_Token_Response $response = null ) {
+	protected function do_add_payment_method_transaction( \WC_Order $order, ?SV_WC_Payment_Gateway_API_Create_Payment_Token_Response $response = null ) {
 
 		if ( is_null( $response ) ) {
 			$response = $this->get_api()->tokenize_payment_method( $order );

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway-my-payment-methods.php
@@ -900,7 +900,7 @@ class SV_WC_Payment_Gateway_My_Payment_Methods extends Handlers\Script_Handler {
 	 * @param SV_WC_Payment_Gateway_Payment_Token|null $token FW token object, only set if the token is a FW token
 	 * @return string
 	 */
-	protected function get_payment_method_default_html( $is_default = false, SV_WC_Payment_Gateway_Payment_Token $token = null ) {
+	protected function get_payment_method_default_html( $is_default = false, ?SV_WC_Payment_Gateway_Payment_Token $token = null ) {
 
 		$html = $is_default ? '<mark class="default">' . esc_html__( 'Default', 'woocommerce-plugin-framework' ) . '</mark>' : '';
 

--- a/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
+++ b/woocommerce/payment-gateway/class-sv-wc-payment-gateway.php
@@ -3376,10 +3376,10 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param \WC_Order $order Optional. The order being charged
+	 * @param \WC_Order|null $order Optional. The order being charged
 	 * @return bool
 	 */
-	public function perform_credit_card_charge( \WC_Order $order = null ) {
+	public function perform_credit_card_charge( ?\WC_Order $order = null ) {
 
 		$this->get_plugin()->assert( $this->supports_credit_card_charge() );
 
@@ -3407,10 +3407,10 @@ abstract class SV_WC_Payment_Gateway extends \WC_Payment_Gateway {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param \WC_Order $order Optional. The order being authorized
+	 * @param \WC_Order|null $order Optional. The order being authorized
 	 * @return bool
 	 */
-	public function perform_credit_card_authorization( \WC_Order $order = null ) {
+	public function perform_credit_card_authorization( ?\WC_Order $order = null ) {
 
 		$this->get_plugin()->assert( $this->supports_credit_card_authorization() );
 

--- a/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
+++ b/woocommerce/payment-gateway/payment-tokens/class-sv-wc-payment-gateway-payment-tokens-handler.php
@@ -295,7 +295,7 @@ class SV_WC_Payment_Gateway_Payment_Tokens_Handler {
 	 * @param string|null $environment_id optional environment id, defaults to plugin current environment
 	 * @return SV_WC_Payment_Gateway_Payment_Token payment token object or null
 	 */
-	public function get_token_by_core_id( int $user_id, int $core_token_id, string $environment_id = null ): ?SV_WC_Payment_Gateway_Payment_Token
+	public function get_token_by_core_id( int $user_id, int $core_token_id, ?string $environment_id = null ): ?SV_WC_Payment_Gateway_Payment_Token
 	{
 		// default to current environment
 		if ( is_null( $environment_id ) ) {


### PR DESCRIPTION
# Summary

This updates method signatures to explicitly mark parameters as nullable, where previously they were implicitly declared as such. This addresses deprecation warnings in PHP 8.4+.

### Story: [MWC-18270](https://godaddy-corp.atlassian.net/browse/MWC-18270)
### Release: TODO

## Details

_Additional details to expand on the summary, if needed_

## QA

TODO

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
